### PR TITLE
Add promise<T> return type (sync-or-async results)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: roxyassert
 Title: Generate Runtime Assertions from roxygen2 Documentation
-Version: 0.1.0
+Version: 0.2.0
 URL: https://dereckscompany.github.io/roxyassert,
     https://github.com/dereckscompany/roxyassert
 BugReports: https://github.com/dereckscompany/roxyassert/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # roxyassert 0.2.0
 
-* New `promise<T>` return type, and the `T | promise<T>` union, for functions
-  whose result may be delivered synchronously **or** as a `promises::promise`
+* New `promise<T>` type (and the `T | promise<T>` union), most natural on
+  `@return`, for functions whose result may be delivered synchronously **or** as
+  a `promises::promise`
   that resolves to the same value (e.g. an exchange wrapper with an `async`
   switch). roxyassert generates a plain value-validator for the resolved type
   `T` and stays promise-agnostic — you compose the async yourself

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,6 @@
   switch). roxyassert generates a plain value-validator for the resolved type
   `T` and stays promise-agnostic — you compose the async yourself
   (`promises::then(impl, assert_return_fn)`, or your own sync/async helper).
-  Allowed in `@return` position only.
 
 # roxyassert 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# roxyassert 0.2.0
+
+* New `promise<T>` return type, and the `T | promise<T>` union, for functions
+  whose result may be delivered synchronously **or** as a `promises::promise`
+  that resolves to the same value (e.g. an exchange wrapper with an `async`
+  switch). roxyassert generates a plain value-validator for the resolved type
+  `T` and stays promise-agnostic — you compose the async yourself
+  (`promises::then(impl, assert_return_fn)`, or your own sync/async helper).
+  Allowed in `@return` position only.
+
 # roxyassert 0.1.0
 
 Initial release.

--- a/R/generate.R
+++ b/R/generate.R
@@ -81,6 +81,9 @@ generate_checks <- function(ast, expr) {
     "function" = sprintf("assert_function(%s)", expr),
     r6 = sprintf('assert_class(%s, "%s")', expr, node$class),
     composite = .rg_composite(node, expr),
+    # parse_annotation normalises promise<T> to its resolved T, so this is only a
+    # safety net: validate the resolved value, never the promise wrapper.
+    promise = .rg_type(node$inner, expr),
     stop("roxyassert: cannot generate for node kind '", node$kind, "'", call. = FALSE)
   ))
 }

--- a/R/generate.R
+++ b/R/generate.R
@@ -81,8 +81,10 @@ generate_checks <- function(ast, expr) {
     "function" = sprintf("assert_function(%s)", expr),
     r6 = sprintf('assert_class(%s, "%s")', expr, node$class),
     composite = .rg_composite(node, expr),
-    # parse_annotation normalises promise<T> to its resolved T, so this is only a
-    # safety net: validate the resolved value, never the promise wrapper.
+    # Defensive only: parse_annotation never yields a promise node here. promise<T>
+    # is unwrapped (recursively) at slot and field level, rejected as a list
+    # element, and rejected inside scalar<>/vector<>. Validate the resolved value,
+    # never the promise wrapper, should that invariant ever change.
     promise = .rg_type(node$inner, expr),
     stop("roxyassert: cannot generate for node kind '", node$kind, "'", call. = FALSE)
   ))

--- a/R/parse.R
+++ b/R/parse.R
@@ -429,17 +429,49 @@ parse_annotation <- function(text) {
     return(ast)
   }
   resolved <- lapply(ast$alternatives, .ra_unwrap_promise)
-  first <- resolved[[1]]
-  if (!all(vapply(resolved, function(a) identical(a, first), logical(1)))) {
+  # Compare the alternatives by their CANONICAL form (refinement text parsed, so
+  # cosmetic spacing in a set / bound does not read as a different type), but keep
+  # the first alternative's ORIGINAL verbatim text for emission.
+  keys <- lapply(resolved, .ra_canonicalize)
+  if (!all(vapply(keys, function(k) identical(k, keys[[1]]), logical(1)))) {
     stop(
-      "roxyassert: every alternative of a promise union must be the identical type ",
-      "(same base AND refinements), e.g. (numeric in [0, 1] | promise<numeric in [0, 1]>); ",
+      "roxyassert: every alternative of a promise union must be the same type ",
+      "(same base, shape AND refinement values), e.g. (numeric in [0, 1] | promise<numeric in [0, 1]>); ",
       "here they differ.",
       call. = FALSE
     )
   }
-  ast$alternatives <- list(first)
+  ast$alternatives <- list(resolved[[1]])
   return(ast)
+}
+
+# Canonicalise a type node for promise-union equality: replace each verbatim
+# refinement string (a set, an interval bound) with its parsed-then-deparsed form
+# so `c(1,2)` and `c(1, 2)` compare equal, recursing into a list<T> element.
+# Structural fields (base, shape, openness, sentinels, |NA, length, class) already
+# compare directly. Used ONLY for the comparison — emission keeps the verbatim text.
+.ra_canonicalize <- function(node) {
+  if (!is.null(node$set)) {
+    node$set$text <- .ra_normexpr(node$set$text)
+  }
+  if (!is.null(node$interval)) {
+    node$interval$lo$text <- .ra_normexpr(node$interval$lo$text)
+    node$interval$hi$text <- .ra_normexpr(node$interval$hi$text)
+  }
+  if (!is.null(node$element)) {
+    node$element <- .ra_canonicalize(node$element)
+  }
+  return(node)
+}
+
+# A refinement expression normalised to a canonical string (whitespace-insensitive
+# via parse/deparse). Falls back to the raw text if it is not a single expression.
+.ra_normexpr <- function(txt) {
+  expr <- tryCatch(parse(text = txt, keep.source = FALSE), error = function(e) NULL)
+  if (is.null(expr) || length(expr) != 1L) {
+    return(txt)
+  }
+  return(paste(deparse(expr[[1]]), collapse = ""))
 }
 
 # ---- type --------------------------------------------------------------------

--- a/R/parse.R
+++ b/R/parse.R
@@ -323,6 +323,10 @@ parse_annotation <- function(text) {
   if (!.ra_eof(sp)) {
     .ra_err(sp, paste0("unexpected trailing input in field slot: '", substr(sp$s, sp$pos, sp$n), "'"))
   }
+  # normalise promises here too, so a field's slot gets the same S5 treatment as
+  # the top level: a heterogeneous promise union is rejected, and a
+  # promise<composite> field collapses to its composite so it can take children.
+  ast <- .ra_normalize_promise(ast)
   if (length(node$children) > 0L) {
     ast <- .ra_attach_fields(ast, lapply(node$children, .ra_finalize_bullet))
   }
@@ -409,20 +413,28 @@ parse_annotation <- function(text) {
 # A promise<T> denotes the resolved type T; a union mixing promise<X> with a bare
 # X (the "sync-or-async delivery" pattern) collapses to a single X. roxyassert
 # validates only the resolved value and emits no promise code (the caller wires
-# the async), so this just reduces the slot to its resolved type — generation and
-# field bullets then see plain T. Allowed in any position (the caller decides how
-# to apply the generated validator to a value or a promise).
+# the async), so this fully unwraps each alternative to its resolved type — every
+# nested promise<...> layer is peeled — leaving generation and field bullets a
+# plain T with no promise node. Applied at the slot AND every field-bullet level.
+.ra_unwrap_promise <- function(node) {
+  if (identical(node$kind, "promise")) {
+    return(.ra_unwrap_promise(node$inner))
+  }
+  return(node)
+}
+
 .ra_normalize_promise <- function(ast) {
   has_promise <- any(vapply(ast$alternatives, function(a) identical(a$kind, "promise"), logical(1)))
   if (!has_promise) {
     return(ast)
   }
-  resolved <- lapply(ast$alternatives, function(a) if (identical(a$kind, "promise")) a$inner else a)
+  resolved <- lapply(ast$alternatives, .ra_unwrap_promise)
   first <- resolved[[1]]
   if (!all(vapply(resolved, function(a) identical(a, first), logical(1)))) {
     stop(
-      "roxyassert: a union with a promise must resolve to a single type ",
-      "(e.g. (T | promise<T>)); its alternatives differ.",
+      "roxyassert: every alternative of a promise union must be the identical type ",
+      "(same base AND refinements), e.g. (numeric in [0, 1] | promise<numeric in [0, 1]>); ",
+      "here they differ.",
       call. = FALSE
     )
   }
@@ -487,6 +499,11 @@ parse_annotation <- function(text) {
     if (w == "list" && .ra_ch(p) == "<") {
       p$pos <- p$pos + 1L
       element <- .ra_parse_type(p)
+      # promise<T> stands for a whole (sync-or-async) slot value, not an element:
+      # a list of promises can't be validated synchronously per element.
+      if (identical(element$kind, "promise")) {
+        .ra_err(p, "promise<T> cannot be a list element; it stands for a whole slot value")
+      }
       .ra_expect(p, ">")
     }
     return(list(kind = "composite", base = w, element = element, fields = NULL))

--- a/R/parse.R
+++ b/R/parse.R
@@ -403,14 +403,15 @@ parse_annotation <- function(text) {
       break
     }
   }
-  return(list(kind = "slot", alternatives = alts, null_ok = null_ok, async = FALSE))
+  return(list(kind = "slot", alternatives = alts, null_ok = null_ok))
 }
 
-# A promise<T> denotes the resolved type T plus an async marker; a union mixing
-# promise<X> with a bare X (the "sync-or-async delivery" pattern) collapses to a
-# single X. roxyassert validates only the resolved value and emits no promise
-# code (the caller wires the async); this just records `async = TRUE` and reduces
-# the slot to its resolved type, so generation and field bullets see plain T.
+# A promise<T> denotes the resolved type T; a union mixing promise<X> with a bare
+# X (the "sync-or-async delivery" pattern) collapses to a single X. roxyassert
+# validates only the resolved value and emits no promise code (the caller wires
+# the async), so this just reduces the slot to its resolved type — generation and
+# field bullets then see plain T. Allowed in any position (the caller decides how
+# to apply the generated validator to a value or a promise).
 .ra_normalize_promise <- function(ast) {
   has_promise <- any(vapply(ast$alternatives, function(a) identical(a$kind, "promise"), logical(1)))
   if (!has_promise) {
@@ -426,7 +427,6 @@ parse_annotation <- function(text) {
     )
   }
   ast$alternatives <- list(first)
-  ast$async <- TRUE
   return(ast)
 }
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -245,6 +245,7 @@ parse_annotation <- function(text) {
   if (!.ra_eof(sp)) {
     .ra_err(sp, paste0("unexpected trailing input: '", substr(sp$s, sp$pos, sp$n), "'"))
   }
+  ast <- .ra_normalize_promise(ast)
   # Everything after the closing ')' is free-text description, which may carry
   # nested `- name (slot)` field bullets (a composite record / typed columns, S1).
   rest <- if (p$pos < p$n) substr(p$s, p$pos + 1L, p$n) else ""
@@ -402,7 +403,31 @@ parse_annotation <- function(text) {
       break
     }
   }
-  return(list(kind = "slot", alternatives = alts, null_ok = null_ok))
+  return(list(kind = "slot", alternatives = alts, null_ok = null_ok, async = FALSE))
+}
+
+# A promise<T> denotes the resolved type T plus an async marker; a union mixing
+# promise<X> with a bare X (the "sync-or-async delivery" pattern) collapses to a
+# single X. roxyassert validates only the resolved value and emits no promise
+# code (the caller wires the async); this just records `async = TRUE` and reduces
+# the slot to its resolved type, so generation and field bullets see plain T.
+.ra_normalize_promise <- function(ast) {
+  has_promise <- any(vapply(ast$alternatives, function(a) identical(a$kind, "promise"), logical(1)))
+  if (!has_promise) {
+    return(ast)
+  }
+  resolved <- lapply(ast$alternatives, function(a) if (identical(a$kind, "promise")) a$inner else a)
+  first <- resolved[[1]]
+  if (!all(vapply(resolved, function(a) identical(a, first), logical(1)))) {
+    stop(
+      "roxyassert: a union with a promise must resolve to a single type ",
+      "(e.g. (T | promise<T>)); its alternatives differ.",
+      call. = FALSE
+    )
+  }
+  ast$alternatives <- list(first)
+  ast$async <- TRUE
+  return(ast)
 }
 
 # ---- type --------------------------------------------------------------------
@@ -445,6 +470,16 @@ parse_annotation <- function(text) {
     }
     .ra_expect(p, ">")
     return(list(kind = "r6", class = cls))
+  }
+  if (w == "promise") {
+    .ra_ws(p)
+    if (.ra_ch(p) != "<") {
+      .ra_err(p, "promise must name its resolved type: promise<T>")
+    }
+    p$pos <- p$pos + 1L
+    inner <- .ra_parse_type(p)
+    .ra_expect(p, ">")
+    return(list(kind = "promise", inner = inner))
   }
   if (w %in% .ra_composite) {
     element <- NULL

--- a/R/parse.R
+++ b/R/parse.R
@@ -502,7 +502,13 @@ parse_annotation <- function(text) {
       # promise<T> stands for a whole (sync-or-async) slot value, not an element:
       # a list of promises can't be validated synchronously per element.
       if (identical(element$kind, "promise")) {
-        .ra_err(p, "promise<T> cannot be a list element; it stands for a whole slot value")
+        .ra_err(
+          p,
+          paste0(
+            "promise<T> cannot be a list element; await the promises ",
+            "(e.g. promises::promise_all) and use promise<list<T>>"
+          )
+        )
       }
       .ra_expect(p, ">")
     }

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -149,14 +149,6 @@ roclet_output.roclet_contract <- function(x, results, base_path, ...) {
   if (is.null(ast)) {
     return(out)
   }
-  if (isTRUE(ast$async)) {
-    stop(
-      "roxyassert: in ",
-      where,
-      ": promise<T> is only valid on @return, not @param (argument checks are synchronous)",
-      call. = FALSE
-    )
-  }
   for (nm in strsplit(names, "\\s*,\\s*")[[1]]) {
     out[[length(out) + 1L]] <- list(name = nm, ast = ast)
   }

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -149,6 +149,14 @@ roclet_output.roclet_contract <- function(x, results, base_path, ...) {
   if (is.null(ast)) {
     return(out)
   }
+  if (isTRUE(ast$async)) {
+    stop(
+      "roxyassert: in ",
+      where,
+      ": promise<T> is only valid on @return, not @param (argument checks are synchronous)",
+      call. = FALSE
+    )
+  }
   for (nm in strsplit(names, "\\s*,\\s*")[[1]]) {
     out[[length(out) + 1L]] <- list(name = nm, ast = ast)
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -132,6 +132,7 @@ The type token in an annotation or a column/field bullet (subject to the per-cat
 | `data.table` | a `data.table` (see composite form) |
 | `data.frame` | a `data.frame` (see composite form) |
 | `R6<Class>` | an R6 instance inheriting `Class` (a bare, length-1 reference) |
+| `promise<T>` | a result resolving to `T`, delivered sync or async (see **Asynchronous returns** below) |
 
 `function` and `R6<Class>` are **reference types**: written bare (`(function)`, `(R6<Engine>)`), nullable as a slot (`(R6<Engine>?)`), never wrapped in `scalar<>`/`vector<>` and never carrying `in`/`| NA`/length. Intervals (`in [ , ]`) apply to the ordered types (`integer`/`numeric`/`Date`/`POSIXct`); sets (`in c(...)`) apply to the ordered and enumerable atomics (`integer`/`numeric`/`Date`/`POSIXct`/`character`/`factor`) — `complex`, `logical`, `raw`, and `any` take no set. `any` asserts nothing about type (length/nullability only). See the [grammar reference](https://dereckscompany.github.io/roxyassert/articles/grammar.html) for the full per-category rules.
 
@@ -255,6 +256,72 @@ open_orders <- function(symbol, statuses) {
 ```
 
 See the [Getting started vignette](https://dereckscompany.github.io/roxyassert/articles/demo.html) for a fuller pattern: an abstract class whose every method enforces its inputs and outputs from the docs.
+
+## Asynchronous returns — `promise<T>`
+
+Many APIs return a result either **synchronously** (the value) or **asynchronously** (a [`promises::promise`](https://rstudio.github.io/promises/) that resolves to the *same* value). roxyassert supports this with two return-only forms:
+
+- `promise<T>` — the function always returns a promise resolving to `T`.
+- `T | promise<T>` — the function returns `T` directly **or** a promise resolving to `T` (e.g. a client with a per-instance `async` switch).
+
+**The key idea: roxyassert stays promise-agnostic.** It generates a *plain value-validator* for the resolved type `T` — `assert_return_fn(value)` validates a `T` and returns it. It never emits `then()` or `is.promise()`. **You** decide how to apply that validator to your promise; because the helper is a `function(value) value`, it is *exactly* the callback `promises::then()` wants.
+
+> **Note:** `promise<T>` is most natural on `@return`, but roxyassert doesn't police it — it's allowed anywhere. A helper that takes a promise *input* (say, to attach a callback) is a fine use case; you just apply the generated validator to the resolved value yourself (e.g. inside your own `promises::then(p, ...)`).
+
+### Always-async (`promise<T>`)
+
+```r
+#' Fetch OHLCV bars.
+#'
+#' @param symbol (scalar<character>) the pair.
+#' @return (promise<data.table>) bars:
+#' - timestamp (POSIXct) candle open time.
+#' - close (numeric in ]0, Inf[) close price.
+#' @export
+ohlcv = function(symbol) {
+  assert_args_ohlcv(symbol)
+  # validator is a then()-callback: validates on resolution, rejects on failure
+  return(promises::then(private$.impl_ohlcv(symbol), assert_return_ohlcv))
+}
+```
+
+The generated `assert_return_ohlcv()` is just the `data.table` + column checks (no promise code). Dropped into `then()`, it validates the resolved table and passes it through; a failing check rejects the returned promise — it never blocks.
+
+### Sync-or-async (`T | promise<T>`)
+
+When the same method can return either shape, document the union and branch on the mode you already know (a constructor flag, here `private$.is_async`):
+
+```r
+#' @return (data.table | promise<data.table>) bars:
+#' - timestamp (POSIXct) candle open time.
+#' - close (numeric in ]0, Inf[) close price.
+ohlcv = function(symbol) {
+  assert_args_ohlcv(symbol)
+  result <- private$.impl_ohlcv(symbol)      # a data.table OR a promise of one
+  if (private$.is_async) {
+    return(promises::then(result, assert_return_ohlcv))  # async: validate on resolve
+  }
+  return(assert_return_ohlcv(result))                    # sync: validate now
+}
+```
+
+A tidy way to capture that branch once is a tiny helper (drop it in your package):
+
+```r
+then_or_now <- function(x, fn, is_async) {
+  if (is_async) return(promises::then(x, fn))
+  return(fn(x))
+}
+
+ohlcv = function(symbol) {
+  assert_args_ohlcv(symbol)
+  return(then_or_now(private$.impl_ohlcv(symbol), assert_return_ohlcv, private$.is_async))
+}
+```
+
+If you don't track the mode explicitly, branch on the value instead — `if (promises::is.promise(result)) promises::then(result, assert_return_ohlcv) else assert_return_ohlcv(result)`.
+
+In all cases the generated validator is identical; only *your* one-line wiring differs.
 
 ## Generated functions — conventions
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -323,6 +323,8 @@ If you don't track the mode explicitly, branch on the value instead — `if (pro
 
 In all cases the generated validator is identical; only *your* one-line wiring differs.
 
+> **Known limitation:** a *list of un-resolved promises* — `list<promise<T>>` — is rejected, because each element would be an unresolved promise that can't be checked synchronously (and roxyassert never emits per-element `then()` wiring). Await them first (e.g. `promises::promise_all`) and annotate the result as `promise<list<T>>`. We'll revisit this if there's demand.
+
 ## Generated functions — conventions
 
 - **Two helpers, each optional.** `assert_args_<fn>` is emitted only if the function has at least one typed `@param`; `assert_return_<fn>` only if `@return` carries a parseable type.

--- a/README.Rmd
+++ b/README.Rmd
@@ -259,7 +259,7 @@ See the [Getting started vignette](https://dereckscompany.github.io/roxyassert/a
 
 ## Asynchronous returns — `promise<T>`
 
-Many APIs return a result either **synchronously** (the value) or **asynchronously** (a [`promises::promise`](https://rstudio.github.io/promises/) that resolves to the *same* value). roxyassert supports this with two return-only forms:
+Many APIs return a result either **synchronously** (the value) or **asynchronously** (a [`promises::promise`](https://rstudio.github.io/promises/) that resolves to the *same* value). roxyassert supports this with two forms:
 
 - `promise<T>` — the function always returns a promise resolving to `T`.
 - `T | promise<T>` — the function returns `T` directly **or** a promise resolving to `T` (e.g. a client with a per-instance `async` switch).

--- a/README.md
+++ b/README.md
@@ -417,6 +417,13 @@ If you don’t track the mode explicitly, branch on the value instead —
 In all cases the generated validator is identical; only *your* one-line
 wiring differs.
 
+> **Known limitation:** a *list of un-resolved promises* —
+> `list<promise<T>>` — is rejected, because each element would be an
+> unresolved promise that can’t be checked synchronously (and roxyassert
+> never emits per-element `then()` wiring). Await them first
+> (e.g. `promises::promise_all`) and annotate the result as
+> `promise<list<T>>`. We’ll revisit this if there’s demand.
+
 ## Generated functions — conventions
 
 - **Two helpers, each optional.** `assert_args_<fn>` is emitted only if

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ by nested bullets, and `list` additionally as `list<T>`):
 | `data.table` | a `data.table` (see composite form) |
 | `data.frame` | a `data.frame` (see composite form) |
 | `R6<Class>` | an R6 instance inheriting `Class` (a bare, length-1 reference) |
+| `promise<T>` | a result resolving to `T`, delivered sync or async (see **Asynchronous returns** below) |
 
 `function` and `R6<Class>` are **reference types**: written bare
 (`(function)`, `(R6<Engine>)`), nullable as a slot (`(R6<Engine>?)`),
@@ -328,6 +329,94 @@ See the [Getting started
 vignette](https://dereckscompany.github.io/roxyassert/articles/demo.html)
 for a fuller pattern: an abstract class whose every method enforces its
 inputs and outputs from the docs.
+
+## Asynchronous returns — `promise<T>`
+
+Many APIs return a result either **synchronously** (the value) or
+**asynchronously** (a
+[`promises::promise`](https://rstudio.github.io/promises/) that resolves
+to the *same* value). roxyassert supports this with two return-only
+forms:
+
+- `promise<T>` — the function always returns a promise resolving to `T`.
+- `T | promise<T>` — the function returns `T` directly **or** a promise
+  resolving to `T` (e.g. a client with a per-instance `async` switch).
+
+**The key idea: roxyassert stays promise-agnostic.** It generates a
+*plain value-validator* for the resolved type `T` —
+`assert_return_fn(value)` validates a `T` and returns it. It never emits
+`then()` or `is.promise()`. **You** decide how to apply that validator
+to your promise; because the helper is a `function(value) value`, it is
+*exactly* the callback `promises::then()` wants.
+
+> **Note:** `promise<T>` is most natural on `@return`, but roxyassert
+> doesn’t police it — it’s allowed anywhere. A helper that takes a
+> promise *input* (say, to attach a callback) is a fine use case; you
+> just apply the generated validator to the resolved value yourself
+> (e.g. inside your own `promises::then(p, ...)`).
+
+### Always-async (`promise<T>`)
+
+``` r
+#' Fetch OHLCV bars.
+#'
+#' @param symbol (scalar<character>) the pair.
+#' @return (promise<data.table>) bars:
+#' - timestamp (POSIXct) candle open time.
+#' - close (numeric in ]0, Inf[) close price.
+#' @export
+ohlcv = function(symbol) {
+  assert_args_ohlcv(symbol)
+  # validator is a then()-callback: validates on resolution, rejects on failure
+  return(promises::then(private$.impl_ohlcv(symbol), assert_return_ohlcv))
+}
+```
+
+The generated `assert_return_ohlcv()` is just the `data.table` + column
+checks (no promise code). Dropped into `then()`, it validates the
+resolved table and passes it through; a failing check rejects the
+returned promise — it never blocks.
+
+### Sync-or-async (`T | promise<T>`)
+
+When the same method can return either shape, document the union and
+branch on the mode you already know (a constructor flag, here
+`private$.is_async`):
+
+``` r
+#' @return (data.table | promise<data.table>) bars:
+#' - timestamp (POSIXct) candle open time.
+#' - close (numeric in ]0, Inf[) close price.
+ohlcv = function(symbol) {
+  assert_args_ohlcv(symbol)
+  result <- private$.impl_ohlcv(symbol)      # a data.table OR a promise of one
+  if (private$.is_async) {
+    return(promises::then(result, assert_return_ohlcv))  # async: validate on resolve
+  }
+  return(assert_return_ohlcv(result))                    # sync: validate now
+}
+```
+
+A tidy way to capture that branch once is a tiny helper (drop it in your
+package):
+
+``` r
+then_or_now <- function(x, fn, is_async) {
+  if (is_async) return(promises::then(x, fn))
+  return(fn(x))
+}
+
+ohlcv = function(symbol) {
+  assert_args_ohlcv(symbol)
+  return(then_or_now(private$.impl_ohlcv(symbol), assert_return_ohlcv, private$.is_async))
+}
+```
+
+If you don’t track the mode explicitly, branch on the value instead —
+`if (promises::is.promise(result)) promises::then(result, assert_return_ohlcv) else assert_return_ohlcv(result)`.
+
+In all cases the generated validator is identical; only *your* one-line
+wiring differs.
 
 ## Generated functions — conventions
 

--- a/README.md
+++ b/README.md
@@ -335,8 +335,7 @@ inputs and outputs from the docs.
 Many APIs return a result either **synchronously** (the value) or
 **asynchronously** (a
 [`promises::promise`](https://rstudio.github.io/promises/) that resolves
-to the *same* value). roxyassert supports this with two return-only
-forms:
+to the *same* value). roxyassert supports this with two forms:
 
 - `promise<T>` — the function always returns a promise resolving to `T`.
 - `T | promise<T>` — the function returns `T` directly **or** a promise

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -411,3 +411,15 @@ test_that("promise<T> over a reference / nullable / nested resolved value", {
   expect_equal(genf("(promise<data.table>?)"), c("if (!is.null(x)) {", "  assert_data_table(x)", "}"))
   expect_equal(genf("(promise<promise<scalar<numeric>>>)"), "assert_scalar_double(x)")
 })
+
+test_that("a refined / reference / composite T | promise<T> union lowers to the resolved T", {
+  expect_equal(
+    genf("(numeric in [0, 1] | promise<numeric in [0, 1]>)"),
+    c("assert_double(x)", "assert_no_missing_values(x)", "assert_between(x, lower = 0, upper = 1)")
+  )
+  expect_equal(genf("(R6<Engine> | promise<R6<Engine>>)"), 'assert_class(x, "Engine")')
+  expect_equal(
+    genf("(list<character> | promise<list<character>>)"),
+    c("assert_list(x)", 'assert_list_of(x, "character")')
+  )
+})

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -385,3 +385,23 @@ test_that("invalid composite-bullet (S1) and misplaced-? forms are rejected", {
   expect_error(parse_annotation("(list<numeric>)\n- a (character) x."), "leaf")
   expect_error(parse_annotation("(list)\n- cur (scalar<character>)? next."), "must sit inside")
 })
+
+test_that("promise<T> / T | promise<T> lower to the resolved type's checks (no promise code)", {
+  expect_equal(genf("(promise<scalar<numeric>>)"), "assert_scalar_double(x)")
+  expect_equal(genf("(promise<data.table>)"), "assert_data_table(x)")
+  expect_equal(genf("(promise<list<character>>)"), c("assert_list(x)", 'assert_list_of(x, "character")'))
+  # the explicit union collapses to the same single validator
+  expect_equal(genf("(data.table | promise<data.table>)"), "assert_data_table(x)")
+  expect_equal(genf("(promise<data.table> | data.table)"), "assert_data_table(x)")
+  # promise<data.table> carries typed columns
+  expect_equal(
+    genf("(promise<data.table>)\n- id (character) i.\n- ok (scalar<logical>) o."),
+    c(
+      "assert_data_table(x)",
+      'assert_has_columns(x, c("id", "ok"))',
+      'assert_character(x[["id"]])',
+      'assert_no_missing_values(x[["id"]])',
+      'assert_scalar_logical(x[["ok"]])'
+    )
+  )
+})

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -405,3 +405,9 @@ test_that("promise<T> / T | promise<T> lower to the resolved type's checks (no p
     )
   )
 })
+
+test_that("promise<T> over a reference / nullable / nested resolved value", {
+  expect_equal(genf("(promise<R6<Engine>>)"), 'assert_class(x, "Engine")')
+  expect_equal(genf("(promise<data.table>?)"), c("if (!is.null(x)) {", "  assert_data_table(x)", "}"))
+  expect_equal(genf("(promise<promise<scalar<numeric>>>)"), "assert_scalar_double(x)")
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -282,5 +282,37 @@ test_that("promise<T> carries field bullets into the resolved composite", {
 
 test_that("promise<T> needs <T>, and a heterogeneous promise union is rejected", {
   expect_error(parse_annotation("(promise)"), "resolved type")
-  expect_error(parse_annotation("(numeric | promise<character>)"), "single type")
+  expect_error(parse_annotation("(numeric | promise<character>)"), "identical type")
+})
+
+# ---- promise<T> edge cases (self-review round) -------------------------------
+
+test_that("nested promise<promise<T>> collapses to the innermost type", {
+  expect_equal(parse_annotation("(promise<promise<data.table>>)")$alternatives[[1]]$base, "data.table")
+  n <- parse_annotation("(promise<promise<data.table>>)\n- id (character) i.")$alternatives[[1]]
+  expect_equal(n$base, "data.table")
+  expect_equal(length(n$fields), 1L)
+})
+
+test_that("promise<T> is a whole-slot value: rejected as a list element / inside scalar<>/vector<>", {
+  expect_error(parse_annotation("(list<promise<numeric>>)"), "list element")
+  expect_error(parse_annotation("(scalar<promise<numeric>>)"), "atomic type or 'any'")
+  expect_error(parse_annotation("(vector<promise<numeric>, 3>)"), "atomic type or 'any'")
+})
+
+test_that("a promise union must be the identical type on every alternative", {
+  expect_equal(parse_annotation("(promise<numeric> | promise<numeric>)")$alternatives[[1]]$base, "numeric")
+  expect_error(parse_annotation("(promise<numeric> | promise<character>)"), "identical type")
+  expect_error(parse_annotation("(numeric in [0, 1] | promise<numeric>)"), "identical type")
+})
+
+test_that("promise normalisation reaches field bullets", {
+  # a heterogeneous promise union in a field is rejected, like at the top level
+  expect_error(parse_annotation("(data.table)\n- x (numeric | promise<character>) c."), "identical type")
+  # a promise<data.table> field collapses, so it can carry its own column bullets
+  rows <- parse_annotation("(list)\n- rows (promise<data.table>) r:\n  - id (character) i.")$alternatives[[1]]$fields[[
+    1
+  ]]$ast$alternatives[[1]]
+  expect_equal(rows$base, "data.table")
+  expect_equal(length(rows$fields), 1L)
 })

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -250,3 +250,46 @@ test_that("a trailing-comma inline set does not raise a misleading empty-element
   expect_silent(parse_annotation("(integer in c(1L,))"))
   expect_error(parse_annotation("(integer in c(1, ))"), "L") # still requires L suffix
 })
+
+# ---- promise<T> (sync-or-async returns) -------------------------------------
+
+test_that("promise<T> records async and collapses to its resolved type", {
+  a <- parse_annotation("(promise<data.table>)")
+  expect_true(a$async)
+  expect_equal(length(a$alternatives), 1L)
+  expect_equal(a$alternatives[[1]]$kind, "composite")
+  expect_equal(a$alternatives[[1]]$base, "data.table")
+  b <- parse_annotation("(promise<scalar<numeric>>)")
+  expect_true(b$async)
+  expect_equal(b$alternatives[[1]]$shape, "scalar")
+  expect_equal(b$alternatives[[1]]$base, "numeric")
+})
+
+test_that("the T | promise<T> union collapses to a single resolved T (async)", {
+  a <- parse_annotation("(data.table | promise<data.table>)")
+  expect_true(a$async)
+  expect_equal(length(a$alternatives), 1L)
+  expect_equal(a$alternatives[[1]]$base, "data.table")
+  b <- parse_annotation("(promise<data.table> | data.table)")
+  expect_true(b$async)
+  expect_equal(length(b$alternatives), 1L)
+})
+
+test_that("promise<T> carries field bullets into the resolved composite", {
+  node <- parse_annotation("(promise<data.table>)\n- id (character) i.\n- score (numeric in [0, 1]) s.")$alternatives[[
+    1
+  ]]
+  expect_equal(node$base, "data.table")
+  expect_equal(length(node$fields), 2L)
+  expect_equal(node$fields[[2]]$name, "score")
+})
+
+test_that("a non-async slot has async = FALSE", {
+  expect_false(parse_annotation("(scalar<numeric>)")$async)
+  expect_false(parse_annotation("(data.table | NULL)")$async)
+})
+
+test_that("promise<T> needs <T>, and a heterogeneous promise union is rejected", {
+  expect_error(parse_annotation("(promise)"), "resolved type")
+  expect_error(parse_annotation("(numeric | promise<character>)"), "single type")
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -282,7 +282,7 @@ test_that("promise<T> carries field bullets into the resolved composite", {
 
 test_that("promise<T> needs <T>, and a heterogeneous promise union is rejected", {
   expect_error(parse_annotation("(promise)"), "resolved type")
-  expect_error(parse_annotation("(numeric | promise<character>)"), "identical type")
+  expect_error(parse_annotation("(numeric | promise<character>)"), "same type")
 })
 
 # ---- promise<T> edge cases (self-review round) -------------------------------
@@ -302,13 +302,13 @@ test_that("promise<T> is a whole-slot value: rejected as a list element / inside
 
 test_that("a promise union must be the identical type on every alternative", {
   expect_equal(parse_annotation("(promise<numeric> | promise<numeric>)")$alternatives[[1]]$base, "numeric")
-  expect_error(parse_annotation("(promise<numeric> | promise<character>)"), "identical type")
-  expect_error(parse_annotation("(numeric in [0, 1] | promise<numeric>)"), "identical type")
+  expect_error(parse_annotation("(promise<numeric> | promise<character>)"), "same type")
+  expect_error(parse_annotation("(numeric in [0, 1] | promise<numeric>)"), "same type")
 })
 
 test_that("promise normalisation reaches field bullets", {
   # a heterogeneous promise union in a field is rejected, like at the top level
-  expect_error(parse_annotation("(data.table)\n- x (numeric | promise<character>) c."), "identical type")
+  expect_error(parse_annotation("(data.table)\n- x (numeric | promise<character>) c."), "same type")
   # a promise<data.table> field collapses, so it can carry its own column bullets
   rows <- parse_annotation("(list)\n- rows (promise<data.table>) r:\n  - id (character) i.")$alternatives[[1]]$fields[[
     1
@@ -323,8 +323,19 @@ test_that("a refined / shape / reference / element promise union collapses iff a
   expect_silent(parse_annotation("(R6<Engine> | promise<R6<Engine>>)"))
   expect_silent(parse_annotation("(list<character> | promise<list<character>>)"))
   # any divergence — refinement value, shape, R6 class, list element — is rejected
-  expect_error(parse_annotation("(numeric in [0, 1] | promise<numeric in ]0, 1[>)"), "identical type")
-  expect_error(parse_annotation("(numeric | promise<scalar<numeric>>)"), "identical type")
-  expect_error(parse_annotation("(R6<A> | promise<R6<B>>)"), "identical type")
-  expect_error(parse_annotation("(list<numeric> | promise<list<integer>>)"), "identical type")
+  expect_error(parse_annotation("(numeric in [0, 1] | promise<numeric in ]0, 1[>)"), "same type")
+  expect_error(parse_annotation("(numeric | promise<scalar<numeric>>)"), "same type")
+  expect_error(parse_annotation("(R6<A> | promise<R6<B>>)"), "same type")
+  expect_error(parse_annotation("(list<numeric> | promise<list<integer>>)"), "same type")
+})
+
+test_that("a promise union compares by meaning, so cosmetic spacing differs harmlessly", {
+  # same set/bound written with different spacing on the two halves still collapses
+  expect_silent(parse_annotation("(numeric in c(1,2) | promise<numeric in c(1, 2)>)"))
+  expect_silent(parse_annotation("(numeric in [0,1] | promise<numeric in [0, 1]>)"))
+  # the emitted check keeps the verbatim text of the first (sync) alternative
+  g <- generate_checks(parse_annotation("(numeric in c(1,2) | promise<numeric in c(1, 2)>)"), "x")
+  expect_true(any(g == "assert_values_in_set(x, c(1,2))"))
+  # a genuine difference in the refinement value is still rejected
+  expect_error(parse_annotation("(numeric in [0, 1] | promise<numeric in ]0, 1[>)"), "same type")
 })

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -251,27 +251,23 @@ test_that("a trailing-comma inline set does not raise a misleading empty-element
   expect_error(parse_annotation("(integer in c(1, ))"), "L") # still requires L suffix
 })
 
-# ---- promise<T> (sync-or-async returns) -------------------------------------
+# ---- promise<T> (sync-or-async results) -------------------------------------
 
-test_that("promise<T> records async and collapses to its resolved type", {
+test_that("promise<T> collapses to its resolved type", {
   a <- parse_annotation("(promise<data.table>)")
-  expect_true(a$async)
   expect_equal(length(a$alternatives), 1L)
   expect_equal(a$alternatives[[1]]$kind, "composite")
   expect_equal(a$alternatives[[1]]$base, "data.table")
   b <- parse_annotation("(promise<scalar<numeric>>)")
-  expect_true(b$async)
   expect_equal(b$alternatives[[1]]$shape, "scalar")
   expect_equal(b$alternatives[[1]]$base, "numeric")
 })
 
-test_that("the T | promise<T> union collapses to a single resolved T (async)", {
+test_that("the T | promise<T> union collapses to a single resolved T", {
   a <- parse_annotation("(data.table | promise<data.table>)")
-  expect_true(a$async)
   expect_equal(length(a$alternatives), 1L)
   expect_equal(a$alternatives[[1]]$base, "data.table")
   b <- parse_annotation("(promise<data.table> | data.table)")
-  expect_true(b$async)
   expect_equal(length(b$alternatives), 1L)
 })
 
@@ -282,11 +278,6 @@ test_that("promise<T> carries field bullets into the resolved composite", {
   expect_equal(node$base, "data.table")
   expect_equal(length(node$fields), 2L)
   expect_equal(node$fields[[2]]$name, "score")
-})
-
-test_that("a non-async slot has async = FALSE", {
-  expect_false(parse_annotation("(scalar<numeric>)")$async)
-  expect_false(parse_annotation("(data.table | NULL)")$async)
 })
 
 test_that("promise<T> needs <T>, and a heterogeneous promise union is rejected", {

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -316,3 +316,15 @@ test_that("promise normalisation reaches field bullets", {
   expect_equal(rows$base, "data.table")
   expect_equal(length(rows$fields), 1L)
 })
+
+test_that("a refined / shape / reference / element promise union collapses iff alternatives are identical", {
+  # identical refinements collapse to the refined T
+  expect_silent(parse_annotation("(numeric in [0, 1] | promise<numeric in [0, 1]>)"))
+  expect_silent(parse_annotation("(R6<Engine> | promise<R6<Engine>>)"))
+  expect_silent(parse_annotation("(list<character> | promise<list<character>>)"))
+  # any divergence — refinement value, shape, R6 class, list element — is rejected
+  expect_error(parse_annotation("(numeric in [0, 1] | promise<numeric in ]0, 1[>)"), "identical type")
+  expect_error(parse_annotation("(numeric | promise<scalar<numeric>>)"), "identical type")
+  expect_error(parse_annotation("(R6<A> | promise<R6<B>>)"), "identical type")
+  expect_error(parse_annotation("(list<numeric> | promise<list<integer>>)"), "identical type")
+})

--- a/tests/testthat/test-roclet.R
+++ b/tests/testthat/test-roclet.R
@@ -122,3 +122,31 @@ test_that("a multi-name @param with a space ('a, b') validates both names", {
   expect_true(any(grepl("assert_scalar_double\\(a\\)", code)))
   expect_true(any(grepl("assert_scalar_double\\(b\\)", code)))
 })
+
+test_that("a promise<T> @return generates a plain resolved-value validator", {
+  text <- "
+    #' Fetch bars.
+    #' @param symbol (scalar<character>) the pair.
+    #' @return (promise<data.table>) bars:
+    #' - t (POSIXct) time.
+    #' - close (numeric in [0, Inf[) price.
+    #' @export
+    get_bars <- function(symbol) NULL
+  "
+  code <- unlist(roxygen2::roc_proc_text(contract_roclet(), text), use.names = FALSE)
+  expect_true(any(grepl("^assert_return_get_bars <- function\\(value\\)", code)))
+  expect_true(any(grepl("assert_data_table\\(value\\)", code)))
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("t", "close"\\)\\)', code)))
+  # roxyassert stays promise-agnostic: no then()/is.promise in the generated code
+  expect_false(any(grepl("promises::then|is\\.promise", code)))
+})
+
+test_that("a promise<T> on @param is rejected (return-only)", {
+  text <- "
+    #' Bad.
+    #' @param p (promise<data.table>) not allowed here.
+    #' @export
+    bad <- function(p) NULL
+  "
+  expect_error(roxygen2::roc_proc_text(contract_roclet(), text), "only valid on @return")
+})

--- a/tests/testthat/test-roclet.R
+++ b/tests/testthat/test-roclet.R
@@ -153,4 +153,6 @@ test_that("a promise<T> @param is allowed — it lowers to the resolved-type che
   code <- unlist(roxygen2::roc_proc_text(contract_roclet(), text), use.names = FALSE)
   expect_true(any(grepl("^assert_args_with_logging <- function\\(p\\)", code)))
   expect_true(any(grepl("assert_data_table\\(p\\)", code)))
+  # promise-agnostic in @param position too: no then()/is.promise emitted
+  expect_false(any(grepl("promises::then|is\\.promise", code)))
 })

--- a/tests/testthat/test-roclet.R
+++ b/tests/testthat/test-roclet.R
@@ -141,12 +141,16 @@ test_that("a promise<T> @return generates a plain resolved-value validator", {
   expect_false(any(grepl("promises::then|is\\.promise", code)))
 })
 
-test_that("a promise<T> on @param is rejected (return-only)", {
+test_that("a promise<T> @param is allowed — it lowers to the resolved-type check", {
+  # a helper that takes a promise input is valid; roxyassert generates the
+  # resolved-value validator and the user applies it however they like.
   text <- "
-    #' Bad.
-    #' @param p (promise<data.table>) not allowed here.
+    #' Add a callback.
+    #' @param p (promise<data.table>) the bars promise.
     #' @export
-    bad <- function(p) NULL
+    with_logging <- function(p) NULL
   "
-  expect_error(roxygen2::roc_proc_text(contract_roclet(), text), "only valid on @return")
+  code <- unlist(roxygen2::roc_proc_text(contract_roclet(), text), use.names = FALSE)
+  expect_true(any(grepl("^assert_args_with_logging <- function\\(p\\)", code)))
+  expect_true(any(grepl("assert_data_table\\(p\\)", code)))
 })

--- a/vignettes/grammar.Rmd
+++ b/vignettes/grammar.Rmd
@@ -715,6 +715,11 @@ model objects are **no longer** here — they are now `list<T>`, e.g.
   `list<T>`.)
 - **A factor's declared `levels()`** — a set checks realised values, not the
   level schema (footnote 2).
+- **A list of un-resolved promises** — `list<promise<T>>` is rejected: each
+  element would be an unresolved promise, which can't be validated synchronously,
+  and roxyassert never emits the per-element `then()` wiring (S5). Await the
+  promises (e.g. `promises::promise_all`) and annotate the result as
+  `promise<list<T>>`. (If there's real demand, a future version could relax this.)
 
 ## 13. Self-consistency checklist
 

--- a/vignettes/grammar.Rmd
+++ b/vignettes/grammar.Rmd
@@ -327,12 +327,12 @@ These context-sensitive constraints are checked by the generator; they are
   value). It stands for a **whole slot value**, so it may not be a `list<>`
   element or sit inside `scalar<>`/`vector<>` (a list of promises cannot be
   validated synchronously per element). The `T | promise<T>` union must resolve to
-  a single `T` — every alternative must be the *identical* type, same base and
-  refinements (a promise unioned with a different type is rejected); nested
-  `promise<promise<T>>` is peeled to `T`. Because refinements (sets, bounds) are
-  compared as the **verbatim text** you wrote (never re-parsed, per §1.6), the two
-  alternatives must be spelled byte-identically: `numeric in c(1, 2)` and
-  `numeric in c(1,2)` do not match — keep them character-for-character the same.
+  a single `T` — every alternative must be the *same* type, same base, shape and
+  refinement values (a promise unioned with a different type is rejected); nested
+  `promise<promise<T>>` is peeled to `T`. Refinements (sets, bounds) are compared
+  by **parsing** them, so cosmetic spacing differs harmlessly — `numeric in c(1, 2)`
+  and `numeric in c(1,2)` match, while `[0, 1]` and `]0, 1[` do not. The emitted
+  check still uses the verbatim text you wrote (§1.6); only the equality test parses.
 
 ## 5. Binding & precedence (why `|` is never ambiguous)
 

--- a/vignettes/grammar.Rmd
+++ b/vignettes/grammar.Rmd
@@ -106,7 +106,7 @@ slot           ::= type ( "|" type )*  ( ( "|" "NULL" ) | "?" )?
                       written EITHER as a "| NULL" alternative OR a trailing "?",
                       never both *)
 
-type           ::= atomic | wildcard | reference | composite
+type           ::= atomic | wildcard | reference | composite | promise
 
 atomic         ::= atom
                  | "scalar" "<" atom ">"
@@ -140,6 +140,13 @@ composite      ::= "list" ( "<" type ">" )? | "data.table" | "data.frame"
                       list<R6<Engine>>, list<any>, list<data.table>. T is a `type`
                       (no slot-level union / `| NULL` / `?`); a `list<T>` is a leaf
                       and takes no bullets (S1, S3). *)
+promise        ::= "promise" "<" type ">"
+                   (* a result resolving to the type T, delivered synchronously
+                      OR as a promises::promise (S5). T is a `type` (a data.table
+                      T may still take field bullets, which describe the resolved
+                      table). A union `T | promise<T>` (same T) is the
+                      sync-or-async pattern and collapses to the single resolved
+                      T. Most natural on @return, but allowed anywhere. *)
 
 int_interval   ::= low int_lo  "," int_hi  high
 num_interval   ::= low num_lo  "," num_hi  high
@@ -301,6 +308,19 @@ These context-sensitive constraints are checked by the generator; they are
   rejected at generation time. (A wrong-side sentinel such as `[Inf, 0]` is caught
   earlier, by the grammar.) `Date`/`POSIXct`/`rexpr` bounds are opaque and not
   range-checked.
+- **S5 — promise<T> is the resolved type, async-agnostic.** A `promise<T>` (and
+  the union `T | promise<T>`, same T) lowers to the checks for the resolved type
+  `T` *only* — roxyassert never emits `promises::then()` or `is.promise()`, because
+  the same generated validator must serve a function whether it works with `T`
+  directly or a promise of `T`. The caller wires the async by applying the
+  generated `function(value) value` validator however they need — it *is* a
+  `then()` callback, e.g. `promises::then(impl, assert_return_fn)` for an
+  always-async result, or branching on a known `async` flag for a sync-or-async
+  one. `promise<T>` is most natural on `@return` but is **allowed in any position**
+  (roxyassert does not police it: a function that takes a promise input is valid;
+  the caller decides how to apply the generated check to the resolved value). The
+  `T | promise<T>` union must resolve to a single `T` (a promise unioned with a
+  *different* type is rejected).
 
 ## 5. Binding & precedence (why `|` is never ambiguous)
 
@@ -343,6 +363,7 @@ atom** — the nearest type to its left, at most one per atom. Thus:
 | `list` | composite | a list — bare = unconstrained; `+ bullets` = named record (S3); `list<T>` = homogeneous (every element `T`) |
 | `data.table` | composite | a `data.table` (typed/list-columns when refined, S3) |
 | `data.frame` | composite | a `data.frame` (typed/list-columns when refined, S3) |
+| `promise<T>` | promise | a result resolving to `T`, sync or async (S5) |
 
 A `list`/`data.table`/`data.frame` **with** nested bullets is a fixed
 named-field structure; **without** bullets it is an unconstrained list/table.
@@ -390,6 +411,11 @@ element is `T` (e.g. `list<character>`, `list<R6<Engine>>`, `list<any>`).
 (list<function>)                  # a list of callbacks
 (list<any>)                       # a list of anything (= bare list at runtime)
 (list<data.table>)                # a list of data.tables
+
+# --- promise returns: resolved type, sync or async ---
+(promise<data.table>)             # a promise resolving to a data.table
+(promise<scalar<numeric>>)        # a promise resolving to one number
+(data.table | promise<data.table>)  # a data.table OR a promise of one (sync-or-async)
 
 # --- vector with explicit length (every atom type) ---
 (vector<numeric, 10>)             # exactly 10
@@ -653,6 +679,8 @@ AbstractStore <- R6::R6Class(
 # (data.table | data.frame): ...  # S1: bullets need a single bare composite
 # (vector<numeric>)               # vector<> requires a length — use bare (numeric)
 # (list<numeric>): ...            # S1: list<T> is a leaf and takes no bullets
+# (promise)                       # promise must name its resolved type: promise<T>
+# (numeric | promise<character>)  # S5: a promise union must resolve to one type
 ```
 
 ## 12. Non-goals (deliberately inexpressible)
@@ -690,5 +718,6 @@ model objects are **no longer** here — they are now `list<T>`, e.g.
 - [ ] `function`/`R6<Class>` appear only as bare reference types; `R6` always names a class.
 - [ ] `list`/`data.table`/`data.frame` carry no `in`/`| NA`/length/`vector<>`; refined by nested bullets (named record / typed columns, S1/S3) **or**, for `list`, parameterised as `list<T>` where `T` is a single `type` (homogeneous, no slot-union/`| NULL`/`?`, a leaf with no bullets); `list<any>` ≡ bare `list` at runtime; a list-column is typed `list<T>`, and an atomic-typed column rejects list-cells.
 - [ ] everything after `)` is free-text description (roxyassert ignores it); a `:` adjacent to it is cosmetic; canonical style omits it.
+- [ ] `promise<T>` lowers to `T`'s checks with no `then()`/`is.promise()` emitted (allowed in any position; the caller wires the async); `T | promise<T>` (same T) collapses to the resolved `T`, and a promise unioned with a different type is rejected (S5).
 - [ ] generated names are `assert_args_<fn>` / `assert_return_<fn>`, and `assert_args_<Class>__<method>` / `assert_return_<Class>__<method>` for R6 (double underscore).
 ```

--- a/vignettes/grammar.Rmd
+++ b/vignettes/grammar.Rmd
@@ -329,7 +329,10 @@ These context-sensitive constraints are checked by the generator; they are
   validated synchronously per element). The `T | promise<T>` union must resolve to
   a single `T` — every alternative must be the *identical* type, same base and
   refinements (a promise unioned with a different type is rejected); nested
-  `promise<promise<T>>` is peeled to `T`.
+  `promise<promise<T>>` is peeled to `T`. Because refinements (sets, bounds) are
+  compared as the **verbatim text** you wrote (never re-parsed, per §1.6), the two
+  alternatives must be spelled byte-identically: `numeric in c(1, 2)` and
+  `numeric in c(1,2)` do not match — keep them character-for-character the same.
 
 ## 5. Binding & precedence (why `|` is never ambiguous)
 

--- a/vignettes/grammar.Rmd
+++ b/vignettes/grammar.Rmd
@@ -65,6 +65,7 @@ exceptions) decides which modifiers are legal:
 | **Wildcard** | `any` | ❌ | ❌ | ❌ | ✅ | bare / `scalar<>` / `vector<>` |
 | **Reference** | `function` `R6<Class>` | ❌ | ❌ | ❌ | ❌ | **bare only** (length-1 by nature) |
 | **Composite** | `list` `data.table` `data.frame` | ❌ | ❌ | ❌ | ❌ | bare, **nested bullets**, or `list<T>` (`list` only) |
+| **Promise** | `promise<T>` | ❌ | ❌ | ❌ | ❌ | wraps one resolved `type` `T`; collapses to `T` (S5) |
 
 ¹ Sets compare with `==`/`%in%` and apply no normalisation. `integer` and
 whole-day `Date` sets (from `as.Date`/`Sys.Date`) are **exact** and fine;
@@ -142,11 +143,15 @@ composite      ::= "list" ( "<" type ">" )? | "data.table" | "data.frame"
                       and takes no bullets (S1, S3). *)
 promise        ::= "promise" "<" type ">"
                    (* a result resolving to the type T, delivered synchronously
-                      OR as a promises::promise (S5). T is a `type` (a data.table
-                      T may still take field bullets, which describe the resolved
-                      table). A union `T | promise<T>` (same T) is the
-                      sync-or-async pattern and collapses to the single resolved
-                      T. Most natural on @return, but allowed anywhere. *)
+                      OR as a promises::promise (S5). T is a single `type` (no
+                      slot-level union / `| NULL` / `?` inside `<>`, as with
+                      list<T>; a data.table T may still take field bullets, which
+                      describe the resolved table). A union `T | promise<T>` (same
+                      T) is the sync-or-async pattern and collapses to the single
+                      resolved T; nested promise<promise<T>> collapses likewise.
+                      promise<T> stands for a whole slot value, so it may NOT be a
+                      list element or sit inside scalar<>/vector<>. Most natural on
+                      @return, but allowed anywhere. *)
 
 int_interval   ::= low int_lo  "," int_hi  high
 num_interval   ::= low num_lo  "," num_hi  high
@@ -316,11 +321,15 @@ These context-sensitive constraints are checked by the generator; they are
   generated `function(value) value` validator however they need — it *is* a
   `then()` callback, e.g. `promises::then(impl, assert_return_fn)` for an
   always-async result, or branching on a known `async` flag for a sync-or-async
-  one. `promise<T>` is most natural on `@return` but is **allowed in any position**
-  (roxyassert does not police it: a function that takes a promise input is valid;
-  the caller decides how to apply the generated check to the resolved value). The
-  `T | promise<T>` union must resolve to a single `T` (a promise unioned with a
-  *different* type is rejected).
+  one. `promise<T>` is most natural on `@return` but is **allowed in any slot
+  position** (roxyassert does not police it: a function that takes a promise input
+  is valid; the caller decides how to apply the generated check to the resolved
+  value). It stands for a **whole slot value**, so it may not be a `list<>`
+  element or sit inside `scalar<>`/`vector<>` (a list of promises cannot be
+  validated synchronously per element). The `T | promise<T>` union must resolve to
+  a single `T` — every alternative must be the *identical* type, same base and
+  refinements (a promise unioned with a different type is rejected); nested
+  `promise<promise<T>>` is peeled to `T`.
 
 ## 5. Binding & precedence (why `|` is never ambiguous)
 
@@ -681,6 +690,8 @@ AbstractStore <- R6::R6Class(
 # (list<numeric>): ...            # S1: list<T> is a leaf and takes no bullets
 # (promise)                       # promise must name its resolved type: promise<T>
 # (numeric | promise<character>)  # S5: a promise union must resolve to one type
+# (list<promise<numeric>>)        # promise<T> is a whole-slot value, not a list element
+# (scalar<promise<numeric>>)      # scalar<>/vector<> wrap an atom or `any`, not a promise
 ```
 
 ## 12. Non-goals (deliberately inexpressible)
@@ -718,6 +729,6 @@ model objects are **no longer** here — they are now `list<T>`, e.g.
 - [ ] `function`/`R6<Class>` appear only as bare reference types; `R6` always names a class.
 - [ ] `list`/`data.table`/`data.frame` carry no `in`/`| NA`/length/`vector<>`; refined by nested bullets (named record / typed columns, S1/S3) **or**, for `list`, parameterised as `list<T>` where `T` is a single `type` (homogeneous, no slot-union/`| NULL`/`?`, a leaf with no bullets); `list<any>` ≡ bare `list` at runtime; a list-column is typed `list<T>`, and an atomic-typed column rejects list-cells.
 - [ ] everything after `)` is free-text description (roxyassert ignores it); a `:` adjacent to it is cosmetic; canonical style omits it.
-- [ ] `promise<T>` lowers to `T`'s checks with no `then()`/`is.promise()` emitted (allowed in any position; the caller wires the async); `T | promise<T>` (same T) collapses to the resolved `T`, and a promise unioned with a different type is rejected (S5).
+- [ ] `promise<T>` lowers to `T`'s checks with no `then()`/`is.promise()` emitted (the caller wires the async); `T | promise<T>` (same T) collapses to the resolved `T`, nested `promise<promise<T>>` collapses too, and a promise unioned with a *different* type is rejected; `promise<T>` is a whole-slot value, so it is rejected as a list element or inside `scalar<>`/`vector<>` (S5).
 - [ ] generated names are `assert_args_<fn>` / `assert_return_<fn>`, and `assert_args_<Class>__<method>` / `assert_return_<Class>__<method>` for R6 (double underscore).
 ```


### PR DESCRIPTION
Adds a `promise<T>` return type, and the union `T | promise<T>`, for functions whose result may be delivered synchronously (the value) or asynchronously (a `promises::promise` resolving to the same value) — e.g. a client with a per-instance `async` switch.

roxyassert generates a plain value-validator for the resolved type `T`: `assert_return_fn(value)` validates a `T` and returns it, and no promise code is emitted. You apply it to your promise yourself — the helper is already the callback `promises::then()` expects:

```r
#' @return (promise<data.table>) bars:
#' - timestamp (POSIXct) candle time.
#' - close (numeric in ]0, Inf[) close price.
ohlcv = function(symbol) {
  assert_args_ohlcv(symbol)
  return(promises::then(private$.impl_ohlcv(symbol), assert_return_ohlcv))
}
```

For the sync-or-async case, document `T | promise<data.table>` and branch on the mode you already track (e.g. an `async` flag) — both branches reuse the same generated validator.

`promise<T>` is most natural on `@return` but is allowed anywhere; roxyassert never blocks it (a helper that takes a promise input is a valid use case — you apply the generated validator to the resolved value yourself). Includes README and grammar-vignette docs, tests, and a NEWS entry.