### PR TITLE
Add @type: reusable named types

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: roxyassert
 Title: Generate Runtime Assertions from roxygen2 Documentation
-Version: 0.2.0
+Version: 0.3.0
 URL: https://dereckscompany.github.io/roxyassert,
     https://github.com/dereckscompany/roxyassert
 BugReports: https://github.com/dereckscompany/roxyassert/issues

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,4 +2,5 @@
 
 S3method(roxygen2::roclet_output,roclet_contract)
 S3method(roxygen2::roclet_process,roclet_contract)
+S3method(roxygen2::roxy_tag_parse,roxy_tag_type)
 export(contract_roclet)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# roxyassert 0.3.0
+
+* New `@type` tag: declare a reusable named type/shape once and reference it by
+  name anywhere a type appears (`@return (promise<OrderAck>)`, `(Bps)`,
+  `list<OrderAck>`), instead of repeating the annotation. Names resolve at
+  `document()` time by inline expansion (no runtime cost); a `@type` may build on
+  another, with cycles and unknown names reported as errors. Package-local.
+  Use-site refinement of a named type (e.g. `(Price in [0, 1])`) is not supported
+  in this version — see Known limitations in the README.
+
 # roxyassert 0.2.0
 
 * New `promise<T>` type (and the `T | promise<T>` union), most natural on

--- a/R/generate.R
+++ b/R/generate.R
@@ -86,6 +86,15 @@ generate_checks <- function(ast, expr) {
     # element, and rejected inside scalar<>/vector<>. Validate the resolved value,
     # never the promise wrapper, should that invariant ever change.
     promise = .rg_type(node$inner, expr),
+    # A named type that reached generation unresolved: not a built-in and not a
+    # registered @type. (The roclet resolves named types first; this is the path
+    # for an undefined reference.)
+    named = stop(
+      "roxyassert: unknown type '",
+      node$name,
+      "' (not a built-in type; define it with @type)",
+      call. = FALSE
+    ),
     stop("roxyassert: cannot generate for node kind '", node$kind, "'", call. = FALSE)
   ))
 }

--- a/R/parse.R
+++ b/R/parse.R
@@ -23,6 +23,9 @@
 .ra_set_ok <- c(.ra_ordered_num, .ra_temporal, .ra_enumerable) # accept `in c(..)`
 .ra_na_ok <- c(.ra_ordered_num, .ra_temporal, .ra_enumerable, .ra_plain) # accept `| NA`
 
+# Built-in type words a @type name may not shadow.
+.ra_type_reserved <- c(.ra_atomic, .ra_composite, "any", "function", "R6", "scalar", "vector", "promise")
+
 # ---- cursor over the annotation text ----------------------------------------
 
 .ra_cursor <- function(s) {
@@ -474,6 +477,43 @@ parse_annotation <- function(text) {
   return(paste(deparse(expr[[1]]), collapse = ""))
 }
 
+# ---- named-type resolution (@type) ------------------------------------------
+#
+# `registry` maps a @type name to its (single-type) AST node. Resolution replaces
+# every `named` node with the registered type, inline and recursively, so the
+# generator only ever sees built-in nodes. A @type may reference another (the
+# substituted node is itself resolved, with `stack` tracking the chain to catch
+# cycles); an unknown name is reported here. Used by the roclet on each annotation
+# AND on the registry entries themselves (so chained types resolve).
+
+.ra_resolve_slot <- function(ast, registry, stack = character()) {
+  ast$alternatives <- lapply(ast$alternatives, function(a) .ra_resolve_node(a, registry, stack))
+  return(ast)
+}
+
+.ra_resolve_node <- function(node, registry, stack = character()) {
+  if (identical(node$kind, "named")) {
+    nm <- node$name
+    if (nm %in% stack) {
+      stop("roxyassert: cyclic @type definition: ", paste(c(stack, nm), collapse = " -> "), call. = FALSE)
+    }
+    if (is.null(registry[[nm]])) {
+      stop("roxyassert: unknown type '", nm, "' (not a built-in type; define it with @type)", call. = FALSE)
+    }
+    return(.ra_resolve_node(registry[[nm]], registry, c(stack, nm)))
+  }
+  if (!is.null(node$element)) {
+    node$element <- .ra_resolve_node(node$element, registry, stack)
+  }
+  if (!is.null(node$fields)) {
+    node$fields <- lapply(node$fields, function(f) {
+      f$ast <- .ra_resolve_slot(f$ast, registry, stack)
+      return(f)
+    })
+  }
+  return(node)
+}
+
 # ---- type --------------------------------------------------------------------
 
 .ra_parse_type <- function(p) {
@@ -552,7 +592,11 @@ parse_annotation <- function(text) {
     node$length <- NULL
     return(node)
   }
-  return(.ra_err(p, paste0("unknown type '", w, "'")))
+  # Not a built-in: a deferred reference to a @type-defined named type. The roclet
+  # resolves it against the type registry; if it is never defined, resolution (or
+  # generation) reports it as an unknown type. A named type takes no in/| NA — it
+  # stands for its whole definition (refine in the @type, not at the use site).
+  return(list(kind = "named", name = w))
 }
 
 # Inside scalar<...> / vector<...>: an atom or the `any` wildcard.

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -64,18 +64,24 @@ roxy_tag_parse.roxy_tag_type <- function(x) {
 }
 
 # Collect every @type definition into a name -> type-node registry, so a bare
-# name in an annotation can be resolved (inline) to its definition. References
-# between @types are resolved later, with cycle detection (R/parse.R).
+# name in an annotation can be resolved (inline) to its definition. Each
+# definition is then resolved eagerly — references between @types are expanded
+# (R/parse.R), so an unknown name or cycle is an error at document() time even
+# when the @type is never used; the returned nodes are fully built-in.
 .ra_type_registry <- function(blocks) {
-  registry <- list()
+  raw <- list()
   for (block in blocks) {
     for (tag in roxygen2::block_get_tags(block, "type")) {
       entry <- .ra_type_def(tag)
-      if (!is.null(registry[[entry$name]])) {
+      if (!is.null(raw[[entry$name]])) {
         stop("roxyassert: duplicate @type '", entry$name, "'", call. = FALSE)
       }
-      registry[[entry$name]] <- entry$node
+      raw[[entry$name]] <- entry$node
     }
+  }
+  registry <- list()
+  for (nm in names(raw)) {
+    registry[[nm]] <- .ra_resolve_node(raw[[nm]], raw, nm)
   }
   return(registry)
 }

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -101,7 +101,7 @@ roxy_tag_parse.roxy_tag_type <- function(x) {
     stop(
       "roxyassert: @type '",
       name,
-      "' must define a single type (no '|' union, '?' or '| NULL' — add those where you use it)",
+      "' must define a single type (no '|' union, '?' or '| NULL'; add those where you use it)",
       call. = FALSE
     )
   }

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -25,9 +25,10 @@ contract_roclet <- function() {
 
 #' @exportS3Method roxygen2::roclet_process
 roclet_process.roclet_contract <- function(x, blocks, env, base_path) {
+  registry <- .ra_type_registry(blocks)
   helpers <- list()
   for (block in blocks) {
-    code <- .ra_block_contract(block)
+    code <- .ra_block_contract(block, registry)
     if (length(code) > 0L) {
       helpers[[length(helpers) + 1L]] <- code
     }
@@ -54,11 +55,64 @@ roclet_output.roclet_contract <- function(x, results, base_path, ...) {
   return(path)
 }
 
+# ---- @type: reusable named types --------------------------------------------
+
+#' @exportS3Method roxygen2::roxy_tag_parse
+roxy_tag_parse.roxy_tag_type <- function(x) {
+  x$val <- x$raw
+  return(x)
+}
+
+# Collect every @type definition into a name -> type-node registry, so a bare
+# name in an annotation can be resolved (inline) to its definition. References
+# between @types are resolved later, with cycle detection (R/parse.R).
+.ra_type_registry <- function(blocks) {
+  registry <- list()
+  for (block in blocks) {
+    for (tag in roxygen2::block_get_tags(block, "type")) {
+      entry <- .ra_type_def(tag)
+      if (!is.null(registry[[entry$name]])) {
+        stop("roxyassert: duplicate @type '", entry$name, "'", call. = FALSE)
+      }
+      registry[[entry$name]] <- entry$node
+    }
+  }
+  return(registry)
+}
+
+# Parse one @type tag into list(name=, node=): a leading name then a single-type
+# annotation. Errors on a missing name/type, a shadowed built-in, or a multi-
+# alternative / nullable definition (those modifiers belong at the use site).
+.ra_type_def <- function(tag) {
+  raw <- .ra_tag_text(tag)
+  m <- regmatches(raw, regexec("^\\s*([A-Za-z.][A-Za-z0-9._]*)\\s+([\\s\\S]*)$", raw, perl = TRUE))[[1]]
+  if (length(m) != 3L) {
+    stop("roxyassert: @type needs a name and a type, e.g. @type OrderAck (data.table)", call. = FALSE)
+  }
+  name <- m[[2]]
+  if (name %in% .ra_type_reserved) {
+    stop("roxyassert: @type cannot shadow the built-in type '", name, "'", call. = FALSE)
+  }
+  ast <- .ra_parse_or_stop(m[[3]], sprintf("@type '%s'", name))
+  if (is.null(ast)) {
+    stop("roxyassert: @type '", name, "' has no parseable (type)", call. = FALSE)
+  }
+  if (length(ast$alternatives) != 1L || isTRUE(ast$null_ok)) {
+    stop(
+      "roxyassert: @type '",
+      name,
+      "' must define a single type (no '|' union, '?' or '| NULL' — add those where you use it)",
+      call. = FALSE
+    )
+  }
+  return(list(name = name, node = ast$alternatives[[1]]))
+}
+
 # ---- per-block: build the helper(s) for one documented object ---------------
 
-.ra_block_contract <- function(block) {
+.ra_block_contract <- function(block, registry = list()) {
   if (inherits(block$object, "r6class")) {
-    return(.ra_block_r6(block))
+    return(.ra_block_r6(block, registry))
   }
 
   fn <- .ra_block_name(block)
@@ -66,9 +120,23 @@ roclet_output.roclet_contract <- function(x, results, base_path, ...) {
     return(character())
   }
 
-  params <- .ra_block_params(block)
+  params <- lapply(.ra_block_params(block), function(p) {
+    p$ast <- .ra_resolve_or_stop(p$ast, registry, sprintf("@param '%s'", p$name))
+    return(p)
+  })
   ret <- .ra_block_return(block)
+  if (!is.null(ret)) {
+    ret <- .ra_resolve_or_stop(ret, registry, "@return")
+  }
   return(.ra_assemble(fn, params, ret))
+}
+
+# Resolve a parsed annotation's named types against the registry, re-raising any
+# error (unknown type, cycle) with the documentation location.
+.ra_resolve_or_stop <- function(ast, registry, where) {
+  return(tryCatch(.ra_resolve_slot(ast, registry), error = function(e) {
+    stop("roxyassert: in ", where, ": ", conditionMessage(e), call. = FALSE)
+  }))
 }
 
 # Stitch a function's annotated params + return into its helper code (shared by
@@ -197,7 +265,7 @@ roclet_output.roclet_contract <- function(x, results, base_path, ...) {
 # roxygen2's own tag->method association so the split matches its RD output, then
 # emit assert_args_<Class>__<method> / assert_return_<Class>__<method> per method.
 
-.ra_block_r6 <- function(block) {
+.ra_block_r6 <- function(block, registry = list()) {
   r6 <- .ra_r6_data(block)
   if (is.null(r6)) {
     return(character())
@@ -212,7 +280,13 @@ roclet_output.roclet_contract <- function(x, results, base_path, ...) {
   out <- character()
   for (method in names(by_method)) {
     info <- by_method[[method]]
-    code <- .ra_assemble(paste0(class, "__", method), info$params, info$ret)
+    where <- sprintf("method %s()", method)
+    params <- lapply(info$params, function(p) {
+      p$ast <- .ra_resolve_or_stop(p$ast, registry, sprintf("@param '%s' of %s", p$name, where))
+      return(p)
+    })
+    ret <- if (!is.null(info$ret)) .ra_resolve_or_stop(info$ret, registry, sprintf("@return of %s", where)) else NULL
+    code <- .ra_assemble(paste0(class, "__", method), params, ret)
     if (length(code) > 0L) {
       out <- c(if (length(out) > 0L) c(out, "") else out, code)
     }

--- a/README.Rmd
+++ b/README.Rmd
@@ -323,6 +323,35 @@ If you don't track the mode explicitly, branch on the value instead — `if (pro
 
 In all cases the generated validator is identical; only *your* one-line wiring differs. (See **Known limitations** for `list<promise<T>>`.)
 
+## Reusable types — `@type`
+
+Repeating the same shape across many functions is tedious and drifts. Declare it once with `@type` and reference it by name anywhere a type appears.
+
+Define (anywhere — e.g. `R/types.R`):
+
+```r
+#' @type OrderAck (data.table) an order acknowledgement:
+#' - order_id (character) the exchange id.
+#' - status (scalar<character in c("FILLED", "REJECTED")>) outcome.
+NULL
+
+#' @type Bps (scalar<numeric in [0, Inf[>)
+NULL
+```
+
+Use anywhere a type goes:
+
+```r
+#' @param ack (OrderAck) the ack.
+#' @param slippage (Bps) allowed slippage.
+#' @return (promise<OrderAck>) the ack, async.
+#' @return (list<OrderAck>) a batch.
+```
+
+A `@type` resolves at `document()` time by **inline expansion** — the generated checks are identical to writing the shape out, with no runtime cost. A `@type` may build on another (`@type Row (data.table) - score (Score) ...`); cycles, unknown names, and duplicate definitions are reported as errors.
+
+Rules: a `@type` defines a *single type* — add `?` / `| NULL` / unions at the **use site**, not the definition; references work bare, nullable, in a union, and inside `list<…>` / `promise<…>`, but not inside `scalar<>` / `vector<>` (define a scalar alias directly, like `Bps`). Types are package-local.
+
 ## Generated functions — conventions
 
 - **Two helpers, each optional.** `assert_args_<fn>` is emitted only if the function has at least one typed `@param`; `assert_return_<fn>` only if `@return` carries a parseable type.
@@ -342,6 +371,7 @@ Packages like [`typed`](https://github.com/moodymudskipper/typed) declare types 
 Things deliberately not supported yet — each is rejected with a clear error, and we'll revisit any of them if there's demand. (The grammar reference's *Non-goals* section is the full formal list.)
 
 - **A list of un-resolved promises** (`list<promise<T>>`) — each element would be an unresolved promise that can't be checked synchronously, and roxyassert never emits per-element `then()` wiring. Await them (e.g. `promises::promise_all`) and annotate the result as `promise<list<T>>`.
+- **Refining a named type at the use site** — once `@type Price (scalar<numeric>)` is defined you can't write `(Price in [0, 1])`; the refinement must live in the definition (define a second `@type`, or write the refined type inline). Named types are also package-local (no cross-package reuse yet).
 
 ## Status
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -372,6 +372,7 @@ Things deliberately not supported yet — each is rejected with a clear error, a
 
 - **A list of un-resolved promises** (`list<promise<T>>`) — each element would be an unresolved promise that can't be checked synchronously, and roxyassert never emits per-element `then()` wiring. Await them (e.g. `promises::promise_all`) and annotate the result as `promise<list<T>>`.
 - **Refining a named type at the use site** — once `@type Price (scalar<numeric>)` is defined you can't write `(Price in [0, 1])`; the refinement must live in the definition (define a second `@type`, or write the refined type inline). Named types are also package-local (no cross-package reuse yet).
+- **A named type shows as its bare name in rendered docs** — `@type` is resolved only for the generated checks, so a help page / pkgdown site shows `(OrderAck)` verbatim, not its expanded shape, with no auto-generated topic or link. To give a type a help page, document its `@type` block like any object (add a title/description and `@name`); reference it as a markdown link (`[OrderAck]`) for a clickable cross-reference. (Auto-generated type pages and links may come later.)
 
 ## Status
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -321,9 +321,7 @@ ohlcv = function(symbol) {
 
 If you don't track the mode explicitly, branch on the value instead — `if (promises::is.promise(result)) promises::then(result, assert_return_ohlcv) else assert_return_ohlcv(result)`.
 
-In all cases the generated validator is identical; only *your* one-line wiring differs.
-
-> **Known limitation:** a *list of un-resolved promises* — `list<promise<T>>` — is rejected, because each element would be an unresolved promise that can't be checked synchronously (and roxyassert never emits per-element `then()` wiring). Await them first (e.g. `promises::promise_all`) and annotate the result as `promise<list<T>>`. We'll revisit this if there's demand.
+In all cases the generated validator is identical; only *your* one-line wiring differs. (See **Known limitations** for `list<promise<T>>`.)
 
 ## Generated functions — conventions
 
@@ -338,6 +336,12 @@ In all cases the generated validator is identical; only *your* one-line wiring d
 ## Why annotations, not in-code types
 
 Packages like [`typed`](https://github.com/moodymudskipper/typed) declare types inside the function body with a custom operator. That works and checks at runtime, but it changes how every function is written. `roxyassert` keeps your R code exactly as it is and treats the documentation you already write as the contract — and because the checks are generated *for* you, you never write a validation function by hand again, even if you choose not to call every one.
+
+## Known limitations
+
+Things deliberately not supported yet — each is rejected with a clear error, and we'll revisit any of them if there's demand. (The grammar reference's *Non-goals* section is the full formal list.)
+
+- **A list of un-resolved promises** (`list<promise<T>>`) — each element would be an unresolved promise that can't be checked synchronously, and roxyassert never emits per-element `then()` wiring. Await them (e.g. `promises::promise_all`) and annotate the result as `promise<list<T>>`.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -415,14 +415,7 @@ If you don’t track the mode explicitly, branch on the value instead —
 `if (promises::is.promise(result)) promises::then(result, assert_return_ohlcv) else assert_return_ohlcv(result)`.
 
 In all cases the generated validator is identical; only *your* one-line
-wiring differs.
-
-> **Known limitation:** a *list of un-resolved promises* —
-> `list<promise<T>>` — is rejected, because each element would be an
-> unresolved promise that can’t be checked synchronously (and roxyassert
-> never emits per-element `then()` wiring). Await them first
-> (e.g. `promises::promise_all`) and annotate the result as
-> `promise<list<T>>`. We’ll revisit this if there’s demand.
+wiring differs. (See **Known limitations** for `list<promise<T>>`.)
 
 ## Generated functions — conventions
 
@@ -458,6 +451,18 @@ written. `roxyassert` keeps your R code exactly as it is and treats the
 documentation you already write as the contract — and because the checks
 are generated *for* you, you never write a validation function by hand
 again, even if you choose not to call every one.
+
+## Known limitations
+
+Things deliberately not supported yet — each is rejected with a clear
+error, and we’ll revisit any of them if there’s demand. (The grammar
+reference’s *Non-goals* section is the full formal list.)
+
+- **A list of un-resolved promises** (`list<promise<T>>`) — each element
+  would be an unresolved promise that can’t be checked synchronously,
+  and roxyassert never emits per-element `then()` wiring. Await them
+  (e.g. `promises::promise_all`) and annotate the result as
+  `promise<list<T>>`.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,45 @@ If you don’t track the mode explicitly, branch on the value instead —
 In all cases the generated validator is identical; only *your* one-line
 wiring differs. (See **Known limitations** for `list<promise<T>>`.)
 
+## Reusable types — `@type`
+
+Repeating the same shape across many functions is tedious and drifts.
+Declare it once with `@type` and reference it by name anywhere a type
+appears.
+
+Define (anywhere — e.g. `R/types.R`):
+
+``` r
+#' @type OrderAck (data.table) an order acknowledgement:
+#' - order_id (character) the exchange id.
+#' - status (scalar<character in c("FILLED", "REJECTED")>) outcome.
+NULL
+
+#' @type Bps (scalar<numeric in [0, Inf[>)
+NULL
+```
+
+Use anywhere a type goes:
+
+``` r
+#' @param ack (OrderAck) the ack.
+#' @param slippage (Bps) allowed slippage.
+#' @return (promise<OrderAck>) the ack, async.
+#' @return (list<OrderAck>) a batch.
+```
+
+A `@type` resolves at `document()` time by **inline expansion** — the
+generated checks are identical to writing the shape out, with no runtime
+cost. A `@type` may build on another
+(`@type Row (data.table) - score (Score) ...`); cycles, unknown names,
+and duplicate definitions are reported as errors.
+
+Rules: a `@type` defines a *single type* — add `?` / `| NULL` / unions
+at the **use site**, not the definition; references work bare, nullable,
+in a union, and inside `list<…>` / `promise<…>`, but not inside
+`scalar<>` / `vector<>` (define a scalar alias directly, like `Bps`).
+Types are package-local.
+
 ## Generated functions — conventions
 
 - **Two helpers, each optional.** `assert_args_<fn>` is emitted only if
@@ -463,6 +502,11 @@ reference’s *Non-goals* section is the full formal list.)
   and roxyassert never emits per-element `then()` wiring. Await them
   (e.g. `promises::promise_all`) and annotate the result as
   `promise<list<T>>`.
+- **Refining a named type at the use site** — once
+  `@type Price (scalar<numeric>)` is defined you can’t write
+  `(Price in [0, 1])`; the refinement must live in the definition
+  (define a second `@type`, or write the refined type inline). Named
+  types are also package-local (no cross-package reuse yet).
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -507,6 +507,13 @@ reference’s *Non-goals* section is the full formal list.)
   `(Price in [0, 1])`; the refinement must live in the definition
   (define a second `@type`, or write the refined type inline). Named
   types are also package-local (no cross-package reuse yet).
+- **A named type shows as its bare name in rendered docs** — `@type` is
+  resolved only for the generated checks, so a help page / pkgdown site
+  shows `(OrderAck)` verbatim, not its expanded shape, with no
+  auto-generated topic or link. To give a type a help page, document its
+  `@type` block like any object (add a title/description and `@name`);
+  reference it as a markdown link (`[OrderAck]`) for a clickable
+  cross-reference. (Auto-generated type pages and links may come later.)
 
 ## Status
 

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -372,8 +372,9 @@ test_that("every intentionally-invalid form is rejected", {
     "(vector<function, 3>)", # function is length-1
     "(R6 | NULL)", # R6 must name a class
     "(data.table | NA)", # | NA is element-level, not composite
-    "(vector<numeric>)", # vector<> requires a length
-    "(frobnicate)" # unknown type
+    "(vector<numeric>)" # vector<> requires a length
+    # NB: an unknown bare word (e.g. "frobnicate") is NOT a parse error — it is a
+    # deferred named-type reference, caught at resolution/generation instead.
   )
   for (a in invalid) {
     expect_error(parse_annotation(a), info = a)

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -123,7 +123,13 @@ test_that("invalid annotations are rejected with clear errors", {
   expect_error(parse_annotation("(numeric | NULL?)"), "nothing may follow")
   expect_error(parse_annotation("(R6)"), "must name a class")
   expect_error(parse_annotation("(scalar<numeric, 1>)"), "expected '>'")
-  expect_error(parse_annotation("(frobnicate)"), "unknown type")
+})
+
+test_that("an unknown bare word is a deferred named type; it errors only when unresolved", {
+  # parse no longer rejects it — it may be a @type defined elsewhere
+  expect_equal(parse_annotation("(frobnicate)")$alternatives[[1]]$kind, "named")
+  # but lowering it without a definition is an unknown-type error
+  expect_error(genf("(frobnicate)"), "unknown type")
 })
 
 # ---- nested field bullets (S1 / S3) -----------------------------------------

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -1,0 +1,90 @@
+# Tests for the @type tag: reusable named types resolved (inline) at document()
+# time. End-to-end via roxygen2::roc_proc_text(); the resolver is also unit-tested.
+
+rt <- function(text) unlist(roxygen2::roc_proc_text(contract_roclet(), text), use.names = FALSE)
+
+test_that("a @type expands inline wherever it is referenced", {
+  text <- "
+    #' @type OrderAck (data.table) an ack:
+    #' - order_id (character) the id.
+    #' - status (scalar<character in c('FILLED', 'REJECTED')>) outcome.
+    NULL
+
+    #' @type Bps (scalar<numeric in [0, Inf[>)
+    NULL
+
+    #' Submit.
+    #' @param ack (OrderAck) the ack.
+    #' @param slippage (Bps) allowed slippage.
+    #' @param maybe (OrderAck?) optional ack.
+    #' @return (promise<OrderAck>) async ack.
+    #' @export
+    submit <- function(ack, slippage, maybe) NULL
+  "
+  code <- rt(text)
+  # the record shape expands (table + columns)
+  expect_true(any(grepl('assert_has_columns\\(ack, c\\("order_id", "status"\\)\\)', code)))
+  expect_true(any(grepl('assert_value_in_set\\(ack\\[\\["status"\\]\\], c\\(.FILLED., .REJECTED.\\)\\)', code)))
+  # the scalar alias expands
+  expect_true(any(grepl("assert_scalar_double\\(slippage\\)", code)))
+  expect_true(any(grepl("assert_between\\(slippage, lower = 0", code)))
+  # nullable use site wraps the expansion
+  expect_true(any(grepl("if \\(!is.null\\(maybe\\)\\)", code)))
+  # promise<OrderAck> return validates the resolved data.table
+  expect_true(any(grepl("^assert_return_submit <- function\\(value\\)", code)))
+  expect_true(any(grepl("assert_data_table\\(value\\)", code)))
+  # the @type blocks themselves generate nothing
+  expect_false(any(grepl("assert_(args|return)_(OrderAck|Bps)", code)))
+})
+
+test_that("a @type may build on another (transitive), and inside list<>", {
+  text <- "
+    #' @type Score (scalar<numeric in [0, 1]>)
+    NULL
+    #' @type Row (data.table) a row:
+    #' - score (Score) the score.
+    NULL
+    #' F.
+    #' @param rows (list<Row>) the rows.
+    #' @return (Row) one row.
+    #' @export
+    f <- function(rows) NULL
+  "
+  code <- rt(text)
+  # list<Row>: each element validated as the resolved Row table
+  expect_true(any(grepl("assert_list\\(rows\\)", code)))
+  expect_true(any(grepl("for \\(.x in rows\\)", code)))
+  expect_true(any(grepl("assert_data_table\\(.x\\)", code)))
+  # transitive: Row.score uses Score's scalar double + interval
+  expect_true(any(grepl('assert_scalar_double\\(value\\[\\["score"\\]\\]\\)', code)))
+  expect_true(any(grepl('assert_between\\(value\\[\\["score"\\]\\], lower = 0, upper = 1\\)', code)))
+})
+
+test_that("@type errors: unknown, duplicate, shadow, non-single-type, cycle", {
+  err <- function(text) tryCatch(rt(text), error = function(e) conditionMessage(e))
+  use_a <- "#' F.\n#' @return (A) x.\n#' @export\nf <- function() NULL"
+  expect_match(err("#' F.\n#' @return (Nope) x.\n#' @export\nf <- function() NULL"), "unknown type")
+  expect_match(err(paste0("#' @type A (numeric)\nNULL\n#' @type A (character)\nNULL\n", use_a)), "duplicate @type")
+  expect_match(err("#' @type numeric (character)\nNULL\n#' F.\n#' @export\nf <- function() NULL"), "shadow")
+  expect_match(err(paste0("#' @type A (numeric | character)\nNULL\n", use_a)), "single type")
+  expect_match(err(paste0("#' @type A (numeric?)\nNULL\n", use_a)), "single type")
+  expect_match(err(paste0("#' @type A (B)\nNULL\n#' @type B (A)\nNULL\n", use_a)), "cyclic")
+})
+
+test_that("a named type cannot sit inside scalar<>/vector<>", {
+  err <- function(text) tryCatch(rt(text), error = function(e) conditionMessage(e))
+  def_a <- "#' @type A (numeric)\nNULL\n"
+  use <- "#' F.\n#' @param x (scalar<A>) y.\n#' @export\nf <- function(x) NULL"
+  expect_match(err(paste0(def_a, use)), "atomic type or 'any'")
+})
+
+test_that("the resolver substitutes named nodes (unit level)", {
+  registry <- list(Price = parse_annotation("(scalar<numeric in [0, Inf[>)")$alternatives[[1]])
+  ast <- parse_annotation("(Price)")
+  expect_equal(ast$alternatives[[1]]$kind, "named")
+  resolved <- .ra_resolve_slot(ast, registry)
+  expect_equal(resolved$alternatives[[1]]$base, "numeric")
+  expect_equal(resolved$alternatives[[1]]$shape, "scalar")
+  # an unknown name errors
+  expect_error(.ra_resolve_slot(parse_annotation("(Missing)"), registry), "unknown type")
+})

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -71,6 +71,15 @@ test_that("@type errors: unknown, duplicate, shadow, non-single-type, cycle", {
   expect_match(err(paste0("#' @type A (B)\nNULL\n#' @type B (A)\nNULL\n", use_a)), "cyclic")
 })
 
+test_that("a broken or cyclic @type errors even when never referenced", {
+  err <- function(text) tryCatch(rt(text), error = function(e) conditionMessage(e))
+  noref <- "#' F.\n#' @export\nf <- function() NULL"
+  # an unused @type whose definition references an unknown type
+  expect_match(err(paste0("#' @type A (Nope)\nNULL\n", noref)), "unknown type")
+  # an unused cyclic pair, not referenced by any function
+  expect_match(err(paste0("#' @type A (B)\nNULL\n#' @type B (A)\nNULL\n", noref)), "cyclic")
+})
+
 test_that("a named type cannot sit inside scalar<>/vector<>", {
   err <- function(text) tryCatch(rt(text), error = function(e) conditionMessage(e))
   def_a <- "#' @type A (numeric)\nNULL\n"

--- a/vignettes/grammar.Rmd
+++ b/vignettes/grammar.Rmd
@@ -107,7 +107,12 @@ slot           ::= type ( "|" type )*  ( ( "|" "NULL" ) | "?" )?
                       written EITHER as a "| NULL" alternative OR a trailing "?",
                       never both *)
 
-type           ::= atomic | wildcard | reference | composite | promise
+type           ::= atomic | wildcard | reference | composite | promise | named
+named          ::= ident
+                   (* an identifier that is not a built-in type: a reference to a
+                      type declared elsewhere with `@type` (S6). Resolved inline at
+                      document() time; takes no in / | NA / bullets at the use site
+                      (refine in the @type, not here). *)
 
 atomic         ::= atom
                  | "scalar" "<" atom ">"
@@ -333,6 +338,17 @@ These context-sensitive constraints are checked by the generator; they are
   by **parsing** them, so cosmetic spacing differs harmlessly — `numeric in c(1, 2)`
   and `numeric in c(1,2)` match, while `[0, 1]` and `]0, 1[` do not. The emitted
   check still uses the verbatim text you wrote (§1.6); only the equality test parses.
+- **S6 — named types (`@type`).** A `@type Name (type)` block declares a reusable
+  named type; a bare `Name` (anything that is not a built-in type) in an annotation
+  is a reference, **resolved inline** at document() time — the generated checks are
+  exactly those of the named type's definition (no runtime cost). A `@type` defines
+  a **single type**: no slot-level `|` union, `?`, or `| NULL` in the definition
+  (those go at the use site). A reference is usable bare, nullable, in a union, and
+  inside `list<…>` / `promise<…>`, but **not** inside `scalar<>`/`vector<>` (define a
+  scalar/vector alias directly) and it takes **no use-site refinement** (`in` / `| NA`
+  / bullets) — the shape lives only in the definition. A `@type` may reference another
+  (resolved transitively); a **cycle**, an **unknown** name, a **duplicate** `@type`,
+  and a name that **shadows a built-in** are all errors. Types are **package-local**.
 
 ## 5. Binding & precedence (why `|` is never ambiguous)
 
@@ -720,6 +736,11 @@ model objects are **no longer** here — they are now `list<T>`, e.g.
   and roxyassert never emits the per-element `then()` wiring (S5). Await the
   promises (e.g. `promises::promise_all`) and annotate the result as
   `promise<list<T>>`. (If there's real demand, a future version could relax this.)
+- **Refining a named type at the use site** — a `@type` reference (S6) expands to
+  its definition as-is; `(Price in [0, 1])` on a named `Price` is not allowed. Put
+  the refinement in the `@type`, define another `@type`, or write the refined type
+  inline. **Cross-package** named types are also out of scope — `@type` is
+  package-local.
 
 ## 13. Self-consistency checklist
 
@@ -738,5 +759,6 @@ model objects are **no longer** here — they are now `list<T>`, e.g.
 - [ ] `list`/`data.table`/`data.frame` carry no `in`/`| NA`/length/`vector<>`; refined by nested bullets (named record / typed columns, S1/S3) **or**, for `list`, parameterised as `list<T>` where `T` is a single `type` (homogeneous, no slot-union/`| NULL`/`?`, a leaf with no bullets); `list<any>` ≡ bare `list` at runtime; a list-column is typed `list<T>`, and an atomic-typed column rejects list-cells.
 - [ ] everything after `)` is free-text description (roxyassert ignores it); a `:` adjacent to it is cosmetic; canonical style omits it.
 - [ ] `promise<T>` lowers to `T`'s checks with no `then()`/`is.promise()` emitted (the caller wires the async); `T | promise<T>` (same T) collapses to the resolved `T`, nested `promise<promise<T>>` collapses too, and a promise unioned with a *different* type is rejected; `promise<T>` is a whole-slot value, so it is rejected as a list element or inside `scalar<>`/`vector<>` (S5).
+- [ ] a bare identifier that is not a built-in type is a `@type` reference (S6), resolved inline to its definition; a `@type` is a single type (no use-site `?`/`|`/`| NULL` in the def), usable bare / nullable / unioned / inside `list<>`/`promise<>` but not inside `scalar<>`/`vector<>`, with no use-site refinement; unknown names, duplicates, built-in shadowing, and cycles are errors; package-local.
 - [ ] generated names are `assert_args_<fn>` / `assert_return_<fn>`, and `assert_args_<Class>__<method>` / `assert_return_<Class>__<method>` for R6 (double underscore).
 ```


### PR DESCRIPTION
Adds a `@type` tag so a type/shape can be declared once and referenced by name anywhere a type appears, instead of repeating the annotation. The motivating case is repeated return shapes (e.g. exchange connectors' OHLCV/orderbook/balance tables).

Define once:
```r
#' @type OrderAck (data.table) an order acknowledgement:
#' - order_id (character) the exchange id.
#' - status (scalar<character in c("FILLED", "REJECTED")>) outcome.
NULL
```
Reference anywhere a type goes:
```r
#' @param ack (OrderAck) the ack.
#' @return (promise<OrderAck>) the ack, async.
#' @return (list<OrderAck>) a batch.
```

A named type resolves at `document()` time by **inline expansion** — the generated code is identical to writing the shape out by hand; no runtime cost, no new dependency.

**Scope (approved):**
- `@type` defines a single type (no `?`/`| NULL`/union in the definition — those go at the use site).
- Usable bare, nullable, in a union, and inside `list<>`/`promise<>`; not inside `scalar<>`/`vector<>`.
- A `@type` may reference another (transitive), with cycle detection. Unknown names, duplicate definitions, shadowing a built-in, and cyclic definitions are errors.
- Package-local.
- **Known limitation:** no use-site refinement of a named type (e.g. `(Price in [0, 1])`) in this version — documented in the README.

Building incrementally; leaving open for review.