### PR TITLE
Support roxygen2 7.x for R6 contract generation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: roxyassert
 Title: Generate Runtime Assertions from roxygen2 Documentation
-Version: 0.3.0
+Version: 0.3.1
 URL: https://dereckscompany.github.io/roxyassert,
     https://github.com/dereckscompany/roxyassert
 BugReports: https://github.com/dereckscompany/roxyassert/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Suggests:
     knitr,
     pkgdown,
     rmarkdown,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# roxyassert 0.3.1
+
+* R6 contract generation now works on roxygen2 7.x as well as 8.x. The method
+    detection no longer calls roxygen2's internal `r6_tag_type()` (added in
+    8.0.0); it derives the same method-vs-class classification directly from the
+    tag and class source lines, so packages pinned to roxygen2 7.3.x can
+    generate R6 method contracts.
+
 # roxyassert 0.3.0
 
 * New `@type` tag: declare a reusable named type/shape once and reference it by

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 # roxyassert 0.3.1
 
 * R6 contract generation now works on roxygen2 7.x as well as 8.x. The method
-    detection no longer calls roxygen2's internal `r6_tag_type()` (added in
-    8.0.0); it derives the same method-vs-class classification directly from the
-    tag and class source lines, so packages pinned to roxygen2 7.3.x can
-    generate R6 method contracts.
+  detection no longer calls roxygen2's internal `r6_tag_type()` (added in
+  8.0.0); it derives the same method-vs-class classification directly from the
+  tag and class source lines, so packages pinned to roxygen2 7.3.x can
+  generate R6 method contracts.
 
 # roxyassert 0.3.0
 

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -310,7 +310,10 @@ roxy_tag_parse.roxy_tag_type <- function(x) {
       next
     }
     method <- if (!is.null(tag$r6method)) tag$r6method else find_method(methods, tag)
-    if (is.null(method) || is.na(method)) {
+    # `method` is a single name, or NA/NULL/empty when the tag could not be
+    # associated with one. Length-guard before is.na(): is.na(NULL) and
+    # is.na(character(0)) are both logical(0), which would break the `if`.
+    if (length(method) != 1L || is.na(method)) {
       next
     }
     if (is.null(by_method[[method]])) {

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -303,11 +303,10 @@ roxy_tag_parse.roxy_tag_type <- function(x) {
 # Group the block's method-level @param/@return tags by method name, in source
 # order, returning method -> list(params = list(list(name=, ast=)), ret = ast).
 .ra_r6_collect <- function(block, methods) {
-  tag_type <- .ra_ns_fn("r6_tag_type")
   find_method <- .ra_ns_fn("find_method_for_tag")
   by_method <- list()
   for (tag in block$tags) {
-    if (!(tag$tag %in% c("param", "return")) || !identical(tag_type(tag, block), "method")) {
+    if (!(tag$tag %in% c("param", "return")) || !.ra_r6_is_method_tag(tag, block)) {
       next
     }
     method <- if (!is.null(tag$r6method)) tag$r6method else find_method(methods, tag)
@@ -326,6 +325,22 @@ roxy_tag_parse.roxy_tag_type <- function(x) {
     }
   }
   return(by_method)
+}
+
+# Does a @param / @return tag document an R6 *method* (rather than the class /
+# constructor)? True when roxygen2 has already bound it to a method (`$r6method`)
+# or it sits inline in the class body (at or below the class's definition line).
+# This is roxygen2's own `r6_tag_type()` rule for these two tag kinds, computed
+# directly from `tag$line` / `block$line` so we do not depend on that internal
+# (it was added in roxygen2 8.0.0 and is absent in 7.x).
+.ra_r6_is_method_tag <- function(tag, block) {
+  if (!is.null(tag$r6method)) {
+    return(TRUE)
+  }
+  if (is.null(block$line) || is.na(tag$line)) {
+    return(FALSE)
+  }
+  return(tag$line >= block$line)
 }
 
 # The `.r6data` tag roxygen2 attaches to an R6 class block, or NULL.

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -337,7 +337,11 @@ roxy_tag_parse.roxy_tag_type <- function(x) {
   if (!is.null(tag$r6method)) {
     return(TRUE)
   }
-  if (is.null(block$line) || is.na(tag$line)) {
+  # Without a binding, fall back to the positional rule. Treat any missing or
+  # NA source line (on either the tag or the class) as "cannot tell" -> not a
+  # method tag, rather than erroring. (`is.na(NULL)` is logical(0), which would
+  # break the `if`, so the NULL checks must come first.)
+  if (is.null(tag$line) || is.null(block$line) || is.na(tag$line) || is.na(block$line)) {
     return(FALSE)
   }
   return(tag$line >= block$line)

--- a/tests/testthat/test-roclet.R
+++ b/tests/testthat/test-roclet.R
@@ -93,6 +93,21 @@ test_that("R6 methods generate <Class>__<method> helpers", {
   expect_true(any(grepl("^assert_return_Store__count <- function\\(value\\)", code)))
 })
 
+test_that(".ra_r6_is_method_tag classifies method vs class tags across roxygen2 versions", {
+  # An explicit r6method binding (roxygen2 >= 8.0.0) is always a method tag.
+  expect_true(.ra_r6_is_method_tag(list(r6method = "get", line = 1L), list(line = 99L)))
+  # Otherwise the rule is positional: a tag inline in the class body (at or below
+  # the class's definition line) documents a method; one above documents the
+  # class / constructor. This is computed directly, so it holds on roxygen2 7.x
+  # (which lacks the `r6_tag_type` internal) as well as 8.x.
+  expect_true(.ra_r6_is_method_tag(list(line = 12L), list(line = 10L)))
+  expect_true(.ra_r6_is_method_tag(list(line = 10L), list(line = 10L)))
+  expect_false(.ra_r6_is_method_tag(list(line = 4L), list(line = 10L)))
+  # Degenerate inputs never misfire as a method tag.
+  expect_false(.ra_r6_is_method_tag(list(line = NA_integer_), list(line = 10L)))
+  expect_false(.ra_r6_is_method_tag(list(line = 5L), list()))
+})
+
 test_that("annotation text + names are read from raw, not markdown-rewritten val", {
   # roxygen2 rewrites $val through markdown when enabled, mangling `<...>` into
   # `\if{html}{\out{<...>}}`; the roclet must read the pristine $raw instead.

--- a/tests/testthat/test-roclet.R
+++ b/tests/testthat/test-roclet.R
@@ -103,9 +103,14 @@ test_that(".ra_r6_is_method_tag classifies method vs class tags across roxygen2 
   expect_true(.ra_r6_is_method_tag(list(line = 12L), list(line = 10L)))
   expect_true(.ra_r6_is_method_tag(list(line = 10L), list(line = 10L)))
   expect_false(.ra_r6_is_method_tag(list(line = 4L), list(line = 10L)))
-  # Degenerate inputs never misfire as a method tag.
+  # Degenerate inputs never misfire as a method tag, and never error: a missing
+  # or NA line on either the tag or the class returns FALSE rather than tripping
+  # the comparison (note `is.na(NULL)` is logical(0), which would break an `if`).
   expect_false(.ra_r6_is_method_tag(list(line = NA_integer_), list(line = 10L)))
+  expect_false(.ra_r6_is_method_tag(list(line = 5L), list(line = NA_integer_)))
   expect_false(.ra_r6_is_method_tag(list(line = 5L), list()))
+  expect_false(.ra_r6_is_method_tag(list(), list(line = 10L)))
+  expect_false(.ra_r6_is_method_tag(list(), list()))
 })
 
 test_that("annotation text + names are read from raw, not markdown-rewritten val", {

--- a/tests/testthat/test-roclet.R
+++ b/tests/testthat/test-roclet.R
@@ -93,6 +93,66 @@ test_that("R6 methods generate <Class>__<method> helpers", {
   expect_true(any(grepl("^assert_return_Store__count <- function\\(value\\)", code)))
 })
 
+test_that("R6 method contracts generate through the real on-disk document() path", {
+  # The roc_proc_text() path above parses in-memory text, where the tag's file
+  # is "<text>" but the method's file is a tempfile. roxygen2 8.0.0 special-cases
+  # "<text>" in find_method_for_tag(); 7.3.x does not, so that path cannot
+  # exercise 7.x faithfully. A real package documents files on disk, where the
+  # tag and the method share the same source file -- the path that matters in
+  # production. This parses an on-disk package and runs the contract roclet over
+  # it, so the R6 method-tag association is tested end to end on whatever
+  # roxygen2 is installed (the original crash and the silent-empty failure both
+  # live here, not in the isolated .ra_r6_is_method_tag unit test).
+  dir <- withr::local_tempdir()
+  dir.create(file.path(dir, "R"))
+  writeLines(
+    c(
+      "Package: r6ondisk",
+      "Title: On-disk R6 generation fixture",
+      "Version: 0.0.0",
+      "Description: Test fixture.",
+      "License: MIT + file LICENSE",
+      "Encoding: UTF-8"
+    ),
+    file.path(dir, "DESCRIPTION")
+  )
+  writeLines(
+    c(
+      "#' @title Store",
+      "#' @description A store of records.",
+      "Store <- R6::R6Class('Store',",
+      "  public = list(",
+      "    #' @description Get records by key.",
+      "    #' @param keys (character) keys to fetch.",
+      "    #' @param limit (scalar<integer in [1, Inf[>?) optional max rows.",
+      "    #' @return (data.table) the records.",
+      "    get = function(keys, limit = NULL) NULL,",
+      "    #' @description Count records.",
+      "    #' @return (scalar<integer in [0, Inf[>) the count.",
+      "    count = function() NULL",
+      "  )",
+      ")"
+    ),
+    file.path(dir, "R", "Store.R")
+  )
+
+  # parse_package() reads the files from disk, so tags and methods carry the
+  # real source path (not "<text>"). roclet_process() for the contract roclet
+  # does not use `env`, so a dummy is fine.
+  blocks <- suppressMessages(roxygen2::parse_package(dir))
+  results <- roxygen2::roclet_process(contract_roclet(), blocks, env = NULL, base_path = dir)
+  code <- unlist(results, use.names = FALSE)
+
+  expect_true(any(grepl("^assert_args_Store__get <- function\\(keys, limit\\)", code)))
+  expect_true(any(grepl("assert_character\\(keys\\)", code)))
+  expect_true(any(grepl("assert_scalar_integer\\(limit\\)", code)))
+  expect_true(any(grepl("^assert_return_Store__get <- function\\(value\\)", code)))
+  expect_true(any(grepl("assert_data_table\\(value\\)", code)))
+  # count() has no params -> only a return helper, matching the method split.
+  expect_false(any(grepl("assert_args_Store__count", code)))
+  expect_true(any(grepl("^assert_return_Store__count <- function\\(value\\)", code)))
+})
+
 test_that(".ra_r6_is_method_tag classifies method vs class tags across roxygen2 versions", {
   # An explicit r6method binding (roxygen2 >= 8.0.0) is always a method tag.
   expect_true(.ra_r6_is_method_tag(list(r6method = "get", line = 1L), list(line = 99L)))


### PR DESCRIPTION
R6 method detection called roxygen2's internal `r6_tag_type()`, which only exists in roxygen2 8.0.0. Packages pinned to roxygen2 7.3.x (the tradebot standard) crashed when documenting R6 classes.

The classification — does a `@param`/`@return` tag document a method or the class itself? — is now computed directly from the tag and class source lines, which is the same rule roxygen2 applies internally. It no longer depends on that internal, so R6 contracts generate on roxygen2 7.x and 8.x alike.

Adds a regression test for the classification and a NEWS entry; bumps to 0.3.1.