### PR TITLE
Add count type and @noassert tag

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: roxyassert
 Title: Generate Runtime Assertions from roxygen2 Documentation
-Version: 0.4.0
+Version: 0.5.0
 URL: https://dereckscompany.github.io/roxyassert,
     https://github.com/dereckscompany/roxyassert
 BugReports: https://github.com/dereckscompany/roxyassert/issues

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,5 +2,6 @@
 
 S3method(roxygen2::roclet_output,roclet_contract)
 S3method(roxygen2::roclet_process,roclet_contract)
+S3method(roxygen2::roxy_tag_parse,roxy_tag_noassert)
 S3method(roxygen2::roxy_tag_parse,roxy_tag_type)
 export(contract_roclet)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# roxyassert 0.5.0
+
+* New `count` type: a non-negative whole number that accepts both `20` and `20L`
+  (lowering to `assert_scalar_count` / `assert_count`), unlike `integer` (strict
+  `20L`) or `numeric` (strict double). It is interval-capable
+  (`scalar<count in [1, Inf[>` is a positive count) but takes no set and no
+  `| NA` — a count is non-negative and never NA. The vector form needs
+  assert (>= 0.0.8) for `assert_count()`.
+* New `@noassert` tag: document a parameter's type without generating its check,
+  for parameters already enforced by a hand-written guard. `@noassert <names>`
+  exempts the named parameters; a bare `@noassert` makes the whole
+  function/method documented-only. Naming a parameter that is not documented is
+  an error. Works for plain functions and R6 methods.
+
 # roxyassert 0.4.0
 
 * New `class<Name>` type for asserting an object's class, generating

--- a/R/generate.R
+++ b/R/generate.R
@@ -15,7 +15,8 @@
   logical = "assert_scalar_logical",
   raw = "assert_scalar_raw",
   Date = "assert_scalar_date",
-  POSIXct = "assert_scalar_datetime"
+  POSIXct = "assert_scalar_datetime",
+  count = "assert_scalar_count"
 )
 .rg_vector_fn <- c(
   integer = "assert_integer",
@@ -26,7 +27,8 @@
   logical = "assert_logical",
   raw = "assert_raw",
   Date = "assert_date",
-  POSIXct = "assert_datetime"
+  POSIXct = "assert_datetime",
+  count = "assert_count"
 )
 .rg_composite_fn <- c(
   list = "assert_list",
@@ -117,7 +119,9 @@ generate_checks <- function(ast, expr) {
     }
   } else {
     checks <- sprintf("%s(%s)", .rg_vector_fn[[base]], expr)
-    if (!na_ok && base != "raw") {
+    # `raw` has no NA; `count` already rejects NA in assert_count — neither needs
+    # a separate no-missing check.
+    if (!na_ok && !(base %in% c("raw", "count"))) {
       checks <- c(checks, sprintf("assert_no_missing_values(%s)", expr))
     }
     if (shape == "vector" && !is.null(node$length)) {

--- a/R/parse.R
+++ b/R/parse.R
@@ -16,10 +16,14 @@
 .ra_temporal <- c("Date", "POSIXct")
 .ra_enumerable <- c("character", "factor")
 .ra_plain <- c("complex", "logical")
-.ra_atomic <- c(.ra_ordered_num, .ra_temporal, .ra_enumerable, .ra_plain, "raw")
+# `count` is a value type, not a storage type: a non-negative whole number that
+# accepts both `20` and `20L` (lowers to assert_scalar_count / assert_count). It
+# is interval-capable (whole-number bounds, like `integer`) but takes no set and
+# no `| NA` — a count is non-negative and never NA by definition.
+.ra_atomic <- c(.ra_ordered_num, .ra_temporal, .ra_enumerable, .ra_plain, "raw", "count")
 .ra_composite <- c("list", "data.table", "data.frame")
 
-.ra_interval_ok <- c(.ra_ordered_num, .ra_temporal) # accept `in [..]`
+.ra_interval_ok <- c(.ra_ordered_num, .ra_temporal, "count") # accept `in [..]`
 .ra_set_ok <- c(.ra_ordered_num, .ra_temporal, .ra_enumerable) # accept `in c(..)`
 .ra_na_ok <- c(.ra_ordered_num, .ra_temporal, .ra_enumerable, .ra_plain) # accept `| NA`
 
@@ -623,7 +627,7 @@ parse_annotation <- function(text) {
     ch <- .ra_ch(p)
     if (ch == "[" || ch == "]") {
       if (!(base %in% .ra_interval_ok)) {
-        .ra_err(p, paste0("interval not allowed on '", base, "' (only integer/numeric/Date/POSIXct)"))
+        .ra_err(p, paste0("interval not allowed on '", base, "' (only integer/numeric/count/Date/POSIXct)"))
       }
       interval <- .ra_parse_interval(p, base)
     } else {
@@ -641,7 +645,8 @@ parse_annotation <- function(text) {
     if (.ra_peek_word(p) == "NA") {
       .ra_read_word(p)
       if (!(base %in% .ra_na_ok)) {
-        .ra_err(p, paste0("'| NA' not allowed on '", base, "' (raw has no NA representation)"))
+        reason <- if (base == "count") "a count is never NA" else "raw has no NA representation"
+        .ra_err(p, paste0("'| NA' not allowed on '", base, "' (", reason, ")"))
       }
       na_ok <- TRUE
     } else {
@@ -712,9 +717,9 @@ parse_annotation <- function(text) {
     }
     return(list(text = "-Inf", sentinel = "-Inf"))
   }
-  if (base == "integer") {
+  if (base == "integer" || base == "count") {
     if (!grepl("^-?[0-9]+$", txt)) {
-      .ra_err(p, paste0("integer bound must be a whole number or -Inf/Inf, got '", txt, "'"))
+      .ra_err(p, paste0("'", base, "' bound must be a whole number or -Inf/Inf, got '", txt, "'"))
     }
   } else if (base %in% .ra_temporal) {
     if (grepl("^-?[0-9]+(\\.[0-9]+)?$", txt)) {

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -63,6 +63,57 @@ roxy_tag_parse.roxy_tag_type <- function(x) {
   return(x)
 }
 
+# ---- @noassert: document a type without generating its check ----------------
+
+#' @exportS3Method roxygen2::roxy_tag_parse
+roxy_tag_parse.roxy_tag_noassert <- function(x) {
+  x$val <- x$raw
+  return(x)
+}
+
+# Split a @noassert tag's text into the param names it exempts. A bare
+# `@noassert` (no names) means the WHOLE function/method: the type still renders
+# in the docs, but no check is generated. Returns list(all=, names=).
+.ra_noassert_split <- function(text) {
+  text <- trimws(text)
+  if (nchar(text) == 0L) {
+    return(list(all = TRUE, names = character()))
+  }
+  names <- strsplit(text, "[,[:space:]]+")[[1]]
+  return(list(all = FALSE, names = names[nzchar(names)]))
+}
+
+# The @noassert directive for a plain-function block: list(all=, names=).
+.ra_block_noassert <- function(block) {
+  out <- list(all = FALSE, names = character())
+  for (tag in roxygen2::block_get_tags(block, "noassert")) {
+    no <- .ra_noassert_split(.ra_tag_text(tag))
+    out$all <- out$all || no$all
+    out$names <- c(out$names, no$names)
+  }
+  return(out)
+}
+
+# Drop the @noassert-exempted params from a param list (name/ast records), after
+# verifying every exempted name actually IS a documented param of `where`.
+.ra_apply_noassert <- function(params, names, where) {
+  if (length(names) == 0L) {
+    return(params)
+  }
+  have <- vapply(params, function(p) p$name, character(1))
+  unknown <- setdiff(names, have)
+  if (length(unknown) > 0L) {
+    stop(
+      "roxyassert: @noassert ",
+      where,
+      " names a parameter that is not documented: ",
+      paste(unknown, collapse = ", "),
+      call. = FALSE
+    )
+  }
+  return(Filter(function(p) !(p$name %in% names), params))
+}
+
 # Collect every @type definition into a name -> type-node registry, so a bare
 # name in an annotation can be resolved (inline) to its definition. Each
 # definition is then resolved eagerly — references between @types are expanded
@@ -126,10 +177,20 @@ roxy_tag_parse.roxy_tag_type <- function(x) {
     return(character())
   }
 
+  no <- .ra_block_noassert(block)
+  if (isTRUE(no$all)) {
+    # Whole function is documented-only: emit no contract.
+    return(character())
+  }
+
+  # Resolve (validate) every documented @param, then drop the @noassert ones from
+  # code generation — their types are still validated and rendered, just not
+  # enforced (a guard does that).
   params <- lapply(.ra_block_params(block), function(p) {
     p$ast <- .ra_resolve_or_stop(p$ast, registry, sprintf("@param '%s'", p$name))
     return(p)
   })
+  params <- .ra_apply_noassert(params, no$names, sprintf("on %s()", fn))
   ret <- .ra_block_return(block)
   if (!is.null(ret)) {
     ret <- .ra_resolve_or_stop(ret, registry, "@return")
@@ -305,8 +366,9 @@ roxy_tag_parse.roxy_tag_type <- function(x) {
 .ra_r6_collect <- function(block, methods) {
   find_method <- .ra_ns_fn("find_method_for_tag")
   by_method <- list()
+  skips <- list() # method -> list(all=, names=), from @noassert
   for (tag in block$tags) {
-    if (!(tag$tag %in% c("param", "return")) || !.ra_r6_is_method_tag(tag, block)) {
+    if (!(tag$tag %in% c("param", "return", "noassert")) || !.ra_r6_is_method_tag(tag, block)) {
       next
     }
     method <- if (!is.null(tag$r6method)) tag$r6method else find_method(methods, tag)
@@ -323,8 +385,28 @@ roxy_tag_parse.roxy_tag_type <- function(x) {
       split <- .ra_param_split(tag)
       where <- sprintf("@param '%s' of method %s()", split$names, method)
       by_method[[method]]$params <- .ra_add_param(by_method[[method]]$params, split$names, split$text, where)
-    } else {
+    } else if (tag$tag == "return") {
       by_method[[method]]$ret <- .ra_parse_or_stop(.ra_tag_text(tag), sprintf("@return of method %s()", method))
+    } else {
+      no <- .ra_noassert_split(.ra_tag_text(tag))
+      if (is.null(skips[[method]])) {
+        skips[[method]] <- list(all = FALSE, names = character())
+      }
+      skips[[method]]$all <- skips[[method]]$all || no$all
+      skips[[method]]$names <- c(skips[[method]]$names, no$names)
+    }
+  }
+  # Apply @noassert per method: a bare directive makes the whole method
+  # documented-only; named params are dropped from its generated check.
+  for (m in names(skips)) {
+    if (isTRUE(skips[[m]]$all)) {
+      by_method[[m]] <- list(params = list(), ret = NULL)
+    } else {
+      by_method[[m]]$params <- .ra_apply_noassert(
+        by_method[[m]]$params,
+        skips[[m]]$names,
+        sprintf("of method %s()", m)
+      )
     }
   }
   return(by_method)

--- a/README.Rmd
+++ b/README.Rmd
@@ -126,6 +126,7 @@ The type token in an annotation or a column/field bullet (subject to the per-cat
 | `factor` | factor |
 | `Date` | `Date` vector |
 | `POSIXct` | date-time vector |
+| `count` | non-negative whole number(s), `20` or `20L` — `assert_scalar_count` / `assert_count` (no `NA`, no set; interval-capable) |
 | `any` | any R object — no type check (the wildcard) |
 | `list` | list — bare = unconstrained; `list<T>` = homogeneous; + bullets = named record |
 | `function` | a function/closure (a bare, length-1 reference) |
@@ -151,11 +152,23 @@ The type token in an annotation or a column/field bullet (subject to the per-cat
 - `NA` elements allowed — `(numeric | NA)`
 - nullable slot — `(scalar<numeric>?)` ≡ `(scalar<numeric> | NULL)` (use one, not both)
 - union of types — `(numeric | character)`
+- a count, `20` or `20L` — `(scalar<count>)`; a positive count — `(scalar<count in [1, Inf[>)`
 - object of a class — `(class<Engine>)`
 - any (no type check) — `(any)`
 - homogeneous list / list-column — `(list<character>)` / `(list<any>)`
 
 Everything composes. For example `(vector<numeric in ]0, 1] | NA, 10>)` means: a numeric vector of length 10, every element in `(0, 1]`, `NA` allowed.
+
+### Documenting a type without enforcing it — `@noassert`
+
+A `(type)` both renders in the help page and generates a check. When a parameter is already validated by a hand-written guard, add **`@noassert`** so the type is still documented but no (redundant) check is generated:
+
+```r
+#' @param symbol (scalar<character>) a normalised BASE/QUOTE pair.
+#' @noassert symbol
+```
+
+`@noassert <names>` exempts the named parameters; a bare `@noassert` makes the whole function (or R6 method) documented-only. Exempted parameters are still parsed and validated — only their code generation is skipped — and naming an undocumented parameter is an error.
 
 ### Composite types — nested bullets
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ by nested bullets, and `list` additionally as `list<T>`):
 | `factor` | factor |
 | `Date` | `Date` vector |
 | `POSIXct` | date-time vector |
+| `count` | non-negative whole number(s), `20` or `20L` — `assert_scalar_count` / `assert_count` (no `NA`, no set; interval-capable) |
 | `any` | any R object — no type check (the wildcard) |
 | `list` | list — bare = unconstrained; `list<T>` = homogeneous; + bullets = named record |
 | `function` | a function/closure (a bare, length-1 reference) |
@@ -216,6 +217,8 @@ for the full per-category rules.
 - nullable slot — `(scalar<numeric>?)` ≡ `(scalar<numeric> | NULL)` (use
   one, not both)
 - union of types — `(numeric | character)`
+- a count, `20` or `20L` — `(scalar<count>)`; a positive count —
+  `(scalar<count in [1, Inf[>)`
 - object of a class — `(class<Engine>)`
 - any (no type check) — `(any)`
 - homogeneous list / list-column — `(list<character>)` / `(list<any>)`
@@ -223,6 +226,23 @@ for the full per-category rules.
 Everything composes. For example `(vector<numeric in ]0, 1] | NA, 10>)`
 means: a numeric vector of length 10, every element in `(0, 1]`, `NA`
 allowed.
+
+### Documenting a type without enforcing it — `@noassert`
+
+A `(type)` both renders in the help page and generates a check. When a
+parameter is already validated by a hand-written guard, add
+**`@noassert`** so the type is still documented but no (redundant) check
+is generated:
+
+``` r
+#' @param symbol (scalar<character>) a normalised BASE/QUOTE pair.
+#' @noassert symbol
+```
+
+`@noassert <names>` exempts the named parameters; a bare `@noassert`
+makes the whole function (or R6 method) documented-only. Exempted
+parameters are still parsed and validated — only their code generation
+is skipped — and naming an undocumented parameter is an error.
 
 ### Composite types — nested bullets
 

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -105,6 +105,24 @@ test_that("vector with an element set / interval, plus length", {
   )
 })
 
+test_that("count = non-negative whole number (double or integer); no NA, no set", {
+  expect_equal(genf("(scalar<count>)"), "assert_scalar_count(x)")
+  expect_equal(genf("(count)"), "assert_count(x)")
+  expect_equal(
+    genf("(scalar<count in [1, Inf[>)"),
+    c("assert_scalar_count(x)", "assert_between(x, lower = 1)")
+  )
+  expect_equal(
+    genf("(scalar<count in [0, 10]>?)"),
+    c("if (!is.null(x)) {", "  assert_scalar_count(x)", "  assert_between(x, lower = 0, upper = 10)", "}")
+  )
+  expect_equal(genf("(vector<count, 3>)"), c("assert_count(x)", "assert_length(x, 3L)"))
+  # count rejects NA, sets, and fractional bounds (it is a whole, finite, >=0 value)
+  expect_error(parse_annotation("(count | NA)"), "never NA")
+  expect_error(parse_annotation("(count in c(1, 2))"), "set not allowed")
+  expect_error(parse_annotation("(scalar<count in [1.5, 3]>)"), "whole number")
+})
+
 test_that("interval openness, sentinels, and bound types (verbatim)", {
   expect_equal(
     genf("(scalar<numeric in [0, 1]>)"),

--- a/tests/testthat/test-roclet.R
+++ b/tests/testthat/test-roclet.R
@@ -236,3 +236,60 @@ test_that("a promise<T> @param is allowed — it lowers to the resolved-type che
   # promise-agnostic in @param position too: no then()/is.promise emitted
   expect_false(any(grepl("promises::then|is\\.promise", code)))
 })
+
+test_that("@noassert documents a param's type but generates no check (plain fn)", {
+  text <- "
+    #' F.
+    #' @param a (scalar<character>) one.
+    #' @param b (scalar<numeric>) two.
+    #' @noassert a
+    #' @export
+    f <- function(a, b) NULL
+  "
+  code <- unlist(roxygen2::roc_proc_text(contract_roclet(), text), use.names = FALSE)
+  expect_true(any(grepl("^assert_args_f <- function\\(b\\)", code)))
+  expect_true(any(grepl("assert_scalar_double\\(b\\)", code)))
+  expect_false(any(grepl("assert_scalar_character", code))) # a's check is skipped
+})
+
+test_that("a bare @noassert makes the whole function documented-only", {
+  text <- "
+    #' F.
+    #' @param a (scalar<character>) one.
+    #' @noassert
+    #' @export
+    f <- function(a) NULL
+  "
+  expect_length(unlist(roxygen2::roc_proc_text(contract_roclet(), text), use.names = FALSE), 0L)
+})
+
+test_that("@noassert naming an undocumented param is an error", {
+  text <- "
+    #' F.
+    #' @param a (scalar<character>) one.
+    #' @noassert zzz
+    #' @export
+    f <- function(a) NULL
+  "
+  expect_error(roxygen2::roc_proc_text(contract_roclet(), text), "not documented")
+})
+
+test_that("@noassert works on an R6 method param", {
+  text <- "
+    #' @title Store
+    #' @description A store.
+    Store <- R6::R6Class('Store',
+      public = list(
+        #' @description Get.
+        #' @param keys (character) keys.
+        #' @param limit (scalar<count in [1, Inf[>?) max rows.
+        #' @noassert keys
+        get = function(keys, limit = NULL) NULL
+      )
+    )
+  "
+  code <- unlist(roxygen2::roc_proc_text(contract_roclet(), text), use.names = FALSE)
+  expect_true(any(grepl("^assert_args_Store__get <- function\\(limit\\)", code)))
+  expect_true(any(grepl("assert_scalar_count\\(limit\\)", code)))
+  expect_false(any(grepl("assert_character\\(keys\\)", code))) # keys skipped
+})

--- a/vignettes/grammar.Rmd
+++ b/vignettes/grammar.Rmd
@@ -62,6 +62,7 @@ exceptions) decides which modifiers are legal:
 | **Enumerable atomic** | `character` `factor` | ❌ | ✅² | ✅ | ✅ | bare / `scalar<>` / `vector<>` |
 | **Plain atomic** | `complex` `logical` | ❌ | ❌ | ✅ | ✅ | bare / `scalar<>` / `vector<>` |
 | **Byte atomic** | `raw` | ❌ | ❌ | ❌ | ✅ | bare / `scalar<>` / `vector<>` |
+| **Count** | `count` | ✅ | ❌ | ❌ | ✅ | bare / `scalar<>` / `vector<>` |
 | **Wildcard** | `any` | ❌ | ❌ | ❌ | ✅ | bare / `scalar<>` / `vector<>` |
 | **Reference** | `function` `class<Class>` | ❌ | ❌ | ❌ | ❌ | **bare only** (length-1 by nature) |
 | **Composite** | `list` `data.table` `data.frame` | ❌ | ❌ | ❌ | ❌ | bare, **nested bullets**, or `list<T>` (`list` only) |
@@ -131,6 +132,9 @@ atom           ::= "integer"     ( "in" ( int_interval  | set ) )?  ( "|" "NA" )
                  | enumerable    ( "in" set )?                      ( "|" "NA" )?
                  | plain                                            ( "|" "NA" )?
                  | "raw"
+                 | "count"       ( "in" int_interval )?
+                   (* count: a non-negative whole number (double OR integer);
+                      whole-number interval bounds like integer; no set, no NA *)
 
 temporal       ::= "Date" | "POSIXct"
 enumerable     ::= "character" | "factor"
@@ -389,6 +393,7 @@ atom** — the nearest type to its left, at most one per atom. Thus:
 | `complex` | plain atomic | complex vector |
 | `logical` | plain atomic | `TRUE`/`FALSE` vector |
 | `raw` | byte atomic | raw vector (no `NA`) |
+| `count` | count | non-negative whole number(s), `20` or `20L` (`assert_scalar_count` / `assert_count`); no `NA`, no set |
 | `any` | wildcard | any R object; no type check (length/nullability only) |
 | `function` | reference | a function/closure (length 1) |
 | `class<Class>` | reference | an object whose class is `Class` — any object system (S3/S4/RC/R6/S7), subclasses match (length 1) |
@@ -429,6 +434,13 @@ element is `T` (e.g. `list<character>`, `list<class<Engine>>`, `list<any>`).
 (scalar<complex>)
 (scalar<raw>)                     # a single byte
 (scalar<logical | NA>)            # tri-state flag: TRUE / FALSE / NA
+
+# --- count: a non-negative whole number (accepts 20 or 20L) ---
+(count)                           # a vector of counts
+(scalar<count>)                   # one count, 0, 1, 2, ...
+(scalar<count in [1, Inf[>)       # a positive count (>= 1)
+(scalar<count in [1, Inf[>?)      # a positive count, or NULL
+(vector<count, 3>)                # three counts
 
 # --- reference types: bare, length-1 by nature ---
 (function)                        # a single function/closure
@@ -752,7 +764,33 @@ model objects are **no longer** here — they are now `list<T>`, e.g.
   inline. **Cross-package** named types are also out of scope — `@type` is
   package-local.
 
-## 13. Self-consistency checklist
+## 13. `@noassert` — document a type without enforcing it
+
+roxyassert couples documentation and enforcement: a `(type)` on a `@param` both
+renders in the help page **and** generates a check. `@noassert` decouples them —
+the type is still shown, but no check is generated — for a parameter that a
+hand-written guard already validates (so the generated check would be redundant,
+or would pre-empt the guard's better error message).
+
+- `@noassert <names>` exempts the named parameters (comma- or space-separated);
+  their `(type)` still renders, but no `assert_*` is emitted for them.
+- A bare `@noassert` makes the **whole** function (or R6 method) documented-only.
+- Naming a parameter that is not documented is an error.
+- Exempted parameters are still parsed and validated (a malformed type is still
+  caught) — only their code generation is skipped.
+- Works for plain functions and R6 methods.
+
+```r
+#' @param symbol (scalar<character>) a normalised BASE/QUOTE pair.
+#' @noassert symbol
+#' ...
+ticker = function(symbol) {
+  assert_normalised_symbol(symbol)   # the guard enforces; symbol's type is doc-only
+  ...
+}
+```
+
+## 14. Self-consistency checklist
 
 - [ ] Every base type sits in exactly one category (§2); every modifier it carries is a ✅ in that category's row — no per-type exceptions.
 - [ ] `in [interval]` appears only on `integer`/`numeric`/`Date`/`POSIXct`; integer bounds are literal whole numbers / `±Inf` (no expression); a `numeric` bound is a number or any expression; a `Date`/`POSIXct` bound must be a class-matching expression, so a bare-number bound (`Date in [0, 1]`) is rejected as a type error (S2); `-Inf` only as the low bound, `Inf` only as the high.
@@ -770,5 +808,7 @@ model objects are **no longer** here — they are now `list<T>`, e.g.
 - [ ] everything after `)` is free-text description (roxyassert ignores it); a `:` adjacent to it is cosmetic; canonical style omits it.
 - [ ] `promise<T>` lowers to `T`'s checks with no `then()`/`is.promise()` emitted (the caller wires the async); `T | promise<T>` (same T) collapses to the resolved `T`, nested `promise<promise<T>>` collapses too, and a promise unioned with a *different* type is rejected; `promise<T>` is a whole-slot value, so it is rejected as a list element or inside `scalar<>`/`vector<>` (S5).
 - [ ] a bare identifier that is not a built-in type is a `@type` reference (S6), resolved inline to its definition; a `@type` is a single type (no use-site `?`/`|`/`| NULL` in the def), usable bare / nullable / unioned / inside `list<>`/`promise<>` but not inside `scalar<>`/`vector<>`, with no use-site refinement; unknown names, duplicates, built-in shadowing, and cycles are errors; package-local.
+- [ ] `count` is a non-negative whole number accepting `20` or `20L` (`assert_scalar_count`/`assert_count`); interval-capable with whole-number bounds; no set, no `| NA`.
+- [ ] `@noassert <names>` (or bare, for the whole block) documents a type but emits no check; exempted params are still validated; an undocumented name is an error.
 - [ ] generated names are `assert_args_<fn>` / `assert_return_<fn>`, and `assert_args_<Class>__<method>` / `assert_return_<Class>__<method>` for R6 (double underscore).
 ```


### PR DESCRIPTION
Two features that let core finish typing every parameter:

**`count` type** — a non-negative whole number accepting both `20` and `20L` (lowers to `assert_scalar_count` / `assert_count`), unlike `integer` (strict `20L`) or `numeric` (strict double). Interval-capable (`scalar<count in [1, Inf[>` is a positive count); no set, no `| NA`. Vector form needs assert (>= 0.0.8) for `assert_count()`.

**`@noassert` tag** — document a parameter's type without generating its check, for params already enforced by a hand-written guard (e.g. a regex). `@noassert <names>` exempts the named params; bare `@noassert` makes the whole function/method documented-only; an undocumented name errors. Plain functions and R6 methods.

Tests, grammar reference, README, NEWS updated; 0.5.0.