### PR TITLE
Add finiteness via open brackets at Inf sentinels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: roxyassert
 Title: Generate Runtime Assertions from roxygen2 Documentation
-Version: 0.5.0
+Version: 0.6.0
 URL: https://dereckscompany.github.io/roxyassert,
     https://github.com/dereckscompany/roxyassert
 BugReports: https://github.com/dereckscompany/roxyassert/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# roxyassert 0.6.0
+
+* Finiteness via interval brackets: on a `numeric`, an **open** bracket at a
+  `±Inf` sentinel now *excludes* that infinity. `scalar<numeric in ]0, Inf[>` is
+  "finite and > 0" (lowering to `assert_between(x, lower = 0, lower_inclusive =
+  FALSE, upper = Inf, upper_inclusive = FALSE)`), and `]-Inf, Inf[` is "any finite
+  double". A **closed** sentinel still means "no bound that side" and is omitted,
+  so `]0, Inf]` is unchanged. This is `numeric`-only — `integer`/`count` cannot be
+  `Inf` and a `Date`/`POSIXct` `Inf` bound would be a type mismatch, so for those
+  a sentinel is omitted regardless of bracket (no behaviour change).
+* As a consequence, the only degenerate both-`±Inf`-sentinel intervals rejected at
+  parse time are now those that bound nothing: both brackets closed (`[-Inf, Inf]`,
+  any type) or a non-`numeric` with open brackets (`integer in ]-Inf, Inf[`).
+  `numeric in ]-Inf, Inf[` is now valid ("any finite double").
+
 # roxyassert 0.5.0
 
 * New `count` type: a non-negative whole number that accepts both `20` and `20L`

--- a/R/generate.R
+++ b/R/generate.R
@@ -130,7 +130,7 @@ generate_checks <- function(ast, expr) {
   }
 
   if (!is.null(node$interval)) {
-    checks <- c(checks, .rg_interval(node$interval, expr, na_ok))
+    checks <- c(checks, .rg_interval(node$interval, expr, na_ok, base))
   }
   if (!is.null(node$set)) {
     checks <- c(checks, .rg_set(node, expr, na_ok))
@@ -205,15 +205,27 @@ generate_checks <- function(ast, expr) {
   return(sprintf("assert_length_between(%s, %dL, %dL)", expr, length$min, length$max))
 }
 
-.rg_interval <- function(interval, expr, na_ok) {
+.rg_interval <- function(interval, expr, na_ok, base) {
+  # Finiteness via an OPEN bracket at a ±Inf sentinel only makes sense for
+  # `numeric`: a double is the one type that can actually BE Inf. `integer`/
+  # `count` can't, and a `Date`/`POSIXct` bound of `Inf` would be a type mismatch
+  # — so for those, a sentinel (open or closed) is omitted as before.
+  finite_ok <- identical(base, "numeric")
+  emit_lo <- is.na(interval$lo$sentinel) || (finite_ok && isTRUE(interval$lo_open))
+  emit_hi <- is.na(interval$hi$sentinel) || (finite_ok && isTRUE(interval$hi_open))
+
   args <- expr
-  if (is.na(interval$lo$sentinel)) {
+  # A real bound is always emitted. A ±Inf sentinel is emitted ONLY when `numeric`
+  # and its bracket is OPEN: `]0, Inf[` then lowers to `upper = Inf,
+  # upper_inclusive = FALSE`, i.e. x < Inf (finite). A CLOSED sentinel
+  # (`]0, Inf]`) means "no bound that side" and is omitted.
+  if (emit_lo) {
     args <- c(args, sprintf("lower = %s", interval$lo$text))
     if (isTRUE(interval$lo_open)) {
       args <- c(args, "lower_inclusive = FALSE")
     }
   }
-  if (is.na(interval$hi$sentinel)) {
+  if (emit_hi) {
     args <- c(args, sprintf("upper = %s", interval$hi$text))
     if (isTRUE(interval$hi_open)) {
       args <- c(args, "upper_inclusive = FALSE")

--- a/R/parse.R
+++ b/R/parse.R
@@ -672,10 +672,23 @@ parse_annotation <- function(text) {
   lo <- .ra_classify_bound(lo_txt, base, "low", p)
   hi <- .ra_classify_bound(hi_txt, base, "high", p)
 
-  # A both-sentinel interval imposes no bound and would lower to a bound-less
-  # assert_between() that aborts at runtime; reject it here instead.
-  if (!is.na(lo$sentinel) && !is.na(hi$sentinel)) {
-    .ra_err(p, "degenerate interval ]-Inf, Inf[: both ends are sentinels, so it bounds nothing; drop the 'in [..]'")
+  # Both ends are ±Inf sentinels, so the interval bounds nothing UNLESS it states
+  # finiteness: only `numeric` can actually BE Inf, so a `numeric` with an OPEN
+  # bracket *excludes* that infinity — `]-Inf, Inf[` (any finite double) is
+  # meaningful. Every other both-sentinel form (both closed `[-Inf, Inf]`, or a
+  # non-numeric like `integer in ]-Inf, Inf[`) would lower to a bound-less
+  # assert_between, so reject it.
+  both_sentinel <- !is.na(lo$sentinel) && !is.na(hi$sentinel)
+  finite_meaningful <- identical(base, "numeric") && (lo_open || hi_open)
+  if (both_sentinel && !finite_meaningful) {
+    .ra_err(
+      p,
+      paste0(
+        "degenerate interval: both ends are -Inf/Inf sentinels, so it bounds nothing; ",
+        "drop the 'in [..]'. For a finiteness constraint use open brackets on a ",
+        "numeric: ']-Inf, Inf[' means 'any finite number'"
+      )
+    )
   }
 
   # S4: reject an empty / reversed interval for literal numeric bounds.

--- a/README.Rmd
+++ b/README.Rmd
@@ -144,8 +144,8 @@ The type token in an annotation or a column/field bullet (subject to the per-cat
 - exactly *n* — `(vector<numeric, 10>)`
 - length range / at least *n* — `(vector<numeric, 1..10>)` / `(vector<numeric, 2..>)`
 - between 1 and 5 (inclusive) — `(scalar<numeric in [1, 5]>)`
-- greater than 0 — `(scalar<numeric in ]0, Inf[>)`
-- at most 1 — `(scalar<numeric in ]-Inf, 1]>)`
+- greater than 0 and finite — `(scalar<numeric in ]0, Inf[>)` (an open bracket at a `±Inf` sentinel excludes that infinity; close it — `]0, Inf]` — to allow `Inf`)
+- at most 1 and finite — `(scalar<numeric in ]-Inf, 1]>)`
 - every element of a vector in a range — `(numeric in [1, 5])`
 - enum, inline set (scalar) — `(scalar<character in c("BUY", "SELL")>)`
 - enum, vector from a constant — `(character in ORDER_SIDE)`

--- a/README.md
+++ b/README.md
@@ -208,8 +208,10 @@ for the full per-category rules.
 - length range / at least *n* — `(vector<numeric, 1..10>)` /
   `(vector<numeric, 2..>)`
 - between 1 and 5 (inclusive) — `(scalar<numeric in [1, 5]>)`
-- greater than 0 — `(scalar<numeric in ]0, Inf[>)`
-- at most 1 — `(scalar<numeric in ]-Inf, 1]>)`
+- greater than 0 and finite — `(scalar<numeric in ]0, Inf[>)` (an open
+  bracket at a `±Inf` sentinel excludes that infinity; close it —
+  `]0, Inf]` — to allow `Inf`)
+- at most 1 and finite — `(scalar<numeric in ]-Inf, 1]>)`
 - every element of a vector in a range — `(numeric in [1, 5])`
 - enum, inline set (scalar) — `(scalar<character in c("BUY", "SELL")>)`
 - enum, vector from a constant — `(character in ORDER_SIDE)`

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -143,11 +143,31 @@ test_that("interval openness, sentinels, and bound types (verbatim)", {
     genf("(scalar<numeric in [-1.5, 2.5]>)"),
     c("assert_scalar_double(x)", "assert_between(x, lower = -1.5, upper = 2.5)")
   )
+  # numeric + OPEN bracket at a ±Inf sentinel = finiteness: emit the exclusive
+  # Inf bound (x < Inf / x > -Inf). A CLOSED sentinel still means "no bound" (omit).
   expect_equal(
     genf("(scalar<numeric in ]0, Inf[>)"),
+    c(
+      "assert_scalar_double(x)",
+      "assert_between(x, lower = 0, lower_inclusive = FALSE, upper = Inf, upper_inclusive = FALSE)"
+    )
+  )
+  expect_equal(
+    genf("(scalar<numeric in ]0, Inf]>)"),
     c("assert_scalar_double(x)", "assert_between(x, lower = 0, lower_inclusive = FALSE)")
   )
-  expect_equal(genf("(scalar<numeric in ]-Inf, 0]>)"), c("assert_scalar_double(x)", "assert_between(x, upper = 0)"))
+  expect_equal(
+    genf("(scalar<numeric in ]-Inf, 0]>)"),
+    c("assert_scalar_double(x)", "assert_between(x, lower = -Inf, lower_inclusive = FALSE, upper = 0)")
+  )
+  expect_equal(
+    genf("(scalar<numeric in ]-Inf, Inf[>)"),
+    c(
+      "assert_scalar_double(x)",
+      "assert_between(x, lower = -Inf, lower_inclusive = FALSE, upper = Inf, upper_inclusive = FALSE)"
+    )
+  )
+  # integer/count can't be Inf, so a sentinel is omitted regardless of bracket.
   expect_equal(genf("(scalar<integer in [1, Inf[>)"), c("assert_scalar_integer(x)", "assert_between(x, lower = 1)"))
   expect_equal(genf("(scalar<integer in ]-Inf, 0]>)"), c("assert_scalar_integer(x)", "assert_between(x, upper = 0)"))
   expect_equal(
@@ -362,7 +382,10 @@ test_that("composite records, typed columns, list-columns, nullable nesting", {
       '  assert_character(x[["id"]])',
       '  assert_no_missing_values(x[["id"]])',
       '  assert_double(x[["amount"]])',
-      '  assert_between(x[["amount"]], lower = 0, lower_inclusive = FALSE, na_ok = TRUE)',
+      paste0(
+        '  assert_between(x[["amount"]], lower = 0, lower_inclusive = FALSE, ',
+        "upper = Inf, upper_inclusive = FALSE, na_ok = TRUE)"
+      ),
       "}"
     )
   )
@@ -381,7 +404,8 @@ test_that("every intentionally-invalid form is rejected", {
     "(character in c(1, 2))", # character set needs string literals
     "(Date in [0, 1])", # bare-number Date bound (type error)
     "(numeric in [Inf, 0])", # Inf is the high sentinel only
-    "(numeric in ]-Inf, Inf[)", # both-sentinel: bounds nothing
+    "(numeric in [-Inf, Inf])", # both-sentinel, both closed: bounds nothing
+    "(integer in ]-Inf, Inf[)", # both-sentinel on a non-numeric: bounds nothing
     "(numeric in ]1, 1[)", # empty / reversed interval
     "(logical in c(TRUE, FALSE))", # logical takes no set
     "(complex in c(0+0i, 1+0i))", # complex takes no set

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -26,7 +26,10 @@ test_that("intervals lower to assert_between with the right flags / sentinels", 
   )
   expect_equal(
     gen("scalar<numeric in ]0, Inf[>"),
-    c("assert_scalar_double(x)", "assert_between(x, lower = 0, lower_inclusive = FALSE)")
+    c(
+      "assert_scalar_double(x)",
+      "assert_between(x, lower = 0, lower_inclusive = FALSE, upper = Inf, upper_inclusive = FALSE)"
+    )
   )
   expect_equal(
     gen('scalar<Date in [as.Date("2024-01-01"), Inf[>'),
@@ -35,6 +38,38 @@ test_that("intervals lower to assert_between with the right flags / sentinels", 
   # interval + | NA on a vector: na-aware between, no missing-value rejection
   g <- gen("numeric in [0, 1] | NA")
   expect_equal(g, c("assert_double(x)", "assert_between(x, lower = 0, upper = 1, na_ok = TRUE)"))
+})
+
+test_that("finiteness: an open bracket at a ±Inf sentinel excludes that infinity (numeric only)", {
+  # open high at Inf -> x < Inf (finite above)
+  expect_equal(
+    gen("scalar<numeric in ]0, Inf[>"),
+    c(
+      "assert_scalar_double(x)",
+      "assert_between(x, lower = 0, lower_inclusive = FALSE, upper = Inf, upper_inclusive = FALSE)"
+    )
+  )
+  # open low at -Inf -> x > -Inf (finite below)
+  expect_equal(
+    gen("scalar<numeric in ]-Inf, 5]>"),
+    c("assert_scalar_double(x)", "assert_between(x, lower = -Inf, lower_inclusive = FALSE, upper = 5)")
+  )
+  # both open sentinels -> any finite double
+  expect_equal(
+    gen("scalar<numeric in ]-Inf, Inf[>"),
+    c(
+      "assert_scalar_double(x)",
+      "assert_between(x, lower = -Inf, lower_inclusive = FALSE, upper = Inf, upper_inclusive = FALSE)"
+    )
+  )
+  # CLOSED sentinel still means "no bound that side": omit it
+  expect_equal(
+    gen("scalar<numeric in ]0, Inf]>"),
+    c("assert_scalar_double(x)", "assert_between(x, lower = 0, lower_inclusive = FALSE)")
+  )
+  # integer/count can't be Inf: a sentinel is omitted regardless of bracket
+  expect_equal(gen("scalar<integer in [1, Inf[>"), c("assert_scalar_integer(x)", "assert_between(x, lower = 1)"))
+  expect_equal(gen("scalar<count in [0, Inf[>"), c("assert_scalar_count(x)", "assert_between(x, lower = 0)"))
 })
 
 test_that("vector lengths", {

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -234,8 +234,12 @@ test_that("S2: inline set element types are checked (no coercion); opaque sets t
   expect_silent(parse_annotation("(integer in pkg::CODES)"))
 })
 
-test_that("S: a both-sentinel interval is rejected (it bounds nothing)", {
-  expect_error(parse_annotation("(scalar<numeric in ]-Inf, Inf[>)"), "degenerate|bounds nothing")
+test_that("S: a both-sentinel interval is rejected unless it states finiteness", {
+  # both closed = bounds nothing (any type); open on a non-numeric = bounds nothing
+  expect_error(parse_annotation("(scalar<numeric in [-Inf, Inf]>)"), "degenerate|bounds nothing")
+  expect_error(parse_annotation("(scalar<integer in ]-Inf, Inf[>)"), "degenerate|bounds nothing")
+  # numeric + open brackets = "any finite double": valid (the one meaningful form)
+  expect_silent(parse_annotation("(scalar<numeric in ]-Inf, Inf[>)"))
 })
 
 # ---- re-review regressions (round 2) -----------------------------------------

--- a/vignettes/grammar.Rmd
+++ b/vignettes/grammar.Rmd
@@ -302,7 +302,14 @@ These context-sensitive constraints are checked by the generator; they are
   (`as.Date(...)`, `as.POSIXct(..., tz = ...)`, `lubridate::ymd_hms(...)`), so the
   user owns constructor/format/tz, and a class/tz mismatch compares silently wrong.
   `Inf`/`-Inf` are open-end **sentinels** — `-Inf` only the low bound, `Inf` only
-  the high — denoting "no bound that side" (the comparison is omitted), not values.
+  the high. A **closed** bracket at a sentinel means "no bound that side" (the
+  comparison is omitted), not a value. On a `numeric`, an **open** bracket at a
+  sentinel instead *excludes that infinity* — a finiteness constraint: `]0, Inf[`
+  is "finite and > 0", `]-Inf, Inf[` is "any finite double" (lowered with
+  `upper = Inf, upper_inclusive = FALSE` / `lower = -Inf, lower_inclusive = FALSE`).
+  Finiteness is `numeric`-only — `integer`/`count` cannot be `Inf` and a
+  `Date`/`POSIXct` `Inf` bound would be a type mismatch, so for those a sentinel is
+  omitted regardless of bracket.
   **With `| NA`** an interval is lowered NA-aware — `all((x in range) | is.na(x))`,
   equivalently checked on `x[!is.na(x)]` — parallel to the set form in footnote 2;
   the default (no `| NA`) rejects NA. An opaque `name_set` or any other `rexpr` is
@@ -477,9 +484,11 @@ element is `T` (e.g. `list<character>`, `list<class<Engine>>`, `list<any>`).
 (scalar<numeric in ]0, 1[>)       # 0 <  x <  1
 (scalar<numeric in ]0, 1]>)       # 0 <  x <= 1
 (scalar<numeric in [-1.5, 2.5]>)  # fractional, signed bounds
-(scalar<numeric in ]0, Inf[>)     # x > 0
-(scalar<numeric in ]-Inf, 0]>)    # x <= 0
-(scalar<integer in [1, Inf[>)     # x >= 1  (integer bounds are whole numbers)
+(scalar<numeric in ]0, Inf[>)     # x > 0 and finite (open bracket excludes Inf)
+(scalar<numeric in ]0, Inf]>)     # x > 0, Inf allowed (closed sentinel: no upper bound)
+(scalar<numeric in ]-Inf, 0]>)    # x <= 0 and finite (open bracket excludes -Inf)
+(scalar<numeric in ]-Inf, Inf[>)  # any finite double
+(scalar<integer in [1, Inf[>)     # x >= 1  (integer can't be Inf, so sentinel omitted)
 (scalar<integer in ]-Inf, 0]>)    # x <= 0  (-Inf is the low sentinel)
 (numeric in [0, 1])               # every element in [0, 1]
 (scalar<Date in [as.Date("2024-01-01"), as.Date("2026-12-31")]>)        # bounds are R exprs, verbatim


### PR DESCRIPTION
## Summary

On a `numeric`, an **open** bracket at a `±Inf` sentinel now *excludes* that infinity — a finiteness constraint:

- `scalar<numeric in ]0, Inf[>` → `assert_between(x, lower = 0, lower_inclusive = FALSE, upper = Inf, upper_inclusive = FALSE)` — "finite and > 0"
- `scalar<numeric in ]-Inf, Inf[>` → "any finite double"

A **closed** sentinel still means "no bound that side" and is omitted, so `]0, Inf]` is unchanged.

Finiteness is **`numeric`-only**: `integer`/`count` cannot be `Inf`, and a `Date`/`POSIXct` `Inf` bound would be a type mismatch — so for those a sentinel is omitted regardless of bracket (no behaviour change).

## Degenerate intervals

The only both-`±Inf`-sentinel intervals rejected at parse time are now those that bound nothing:

- both brackets closed — `[-Inf, Inf]` (any type)
- a non-`numeric` with open brackets — `integer in ]-Inf, Inf[`

`numeric in ]-Inf, Inf[` is now **valid** ("any finite double").

## Motivation

Lets order-book params (prices, quantities) be typed `scalar<numeric in ]0, Inf[>` — positive *and* finite — without a separate hand-written `assert_all_finite` guard. No new `assert` function is required (reuses `assert_between` with `*_inclusive = FALSE` on the `Inf` bound).

## Changes

- `R/parse.R` — relax the degenerate both-sentinel check to the numeric-with-open exception
- `R/generate.R` — `.rg_interval` emits an exclusive `±Inf` bound for an open `numeric` sentinel
- Tests: coverage / generate / parse — updated expectations + a dedicated finiteness block
- Docs: grammar vignette §S2, README, NEWS; bump to 0.6.0

## Checks

`R CMD check`: 0 errors, 0 warnings, 1 pre-existing NOTE (License stub). `lintr`: clean. 443 tests pass.