### PR TITLE
@type record derivation: extends, override, pick/omit (named + inline)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: roxyassert
 Title: Generate Runtime Assertions from roxygen2 Documentation
-Version: 0.8.0
+Version: 0.9.0
 URL: https://dereckscompany.github.io/roxyassert,
     https://github.com/dereckscompany/roxyassert
 BugReports: https://github.com/dereckscompany/roxyassert/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,27 @@
+# roxyassert 0.9.0
+
+* **Record-type derivation for `@type`** — build one record shape from another
+  instead of copying columns, the same idea as TypeScript's `extends` / `Pick` /
+  `Omit`. Inside the parentheses (the kind is inherited from the base, never
+  restated):
+
+  * **`extends Base`** — inherit the base's columns, then add new ones as bullets:
+    `@type OrderModifyResult (extends Order):` plus the modify-only columns.
+  * **Override** — redeclaring an inherited column by name replaces it in place
+    (a trusted full replacement; roxyassert has no subtype lattice, so it is not
+    checked for being a narrowing).
+  * **Multiple inheritance** — `(extends A, B)`; a column defined by more than one
+    base is an error unless the derived type redeclares it.
+  * **`pick` / `omit`** — `(extends Order pick id, status)` /
+    `(extends Order omit secret)`; mutually exclusive, names must exist in a base.
+
+  Works both as a named `@type` and **inline** in a `@param`/`@return`
+  (`@return (extends Order):` + bullets). Pure `document()`-time column splicing —
+  it reuses the existing `@type` registry, cycle / unknown-base detection, and
+  lowering, with no runtime cost and no change to generated code. Column *renaming*
+  and *generic / parameterized* types remain out of scope (see the grammar
+  vignette's *Non-goals*).
+
 # roxyassert 0.8.0
 
 * New tag **`@genassert`**: on a block that defines one or more `@type`, emit a

--- a/R/generate.R
+++ b/R/generate.R
@@ -150,6 +150,16 @@ generate_checks <- function(ast, expr) {
 }
 
 .rg_composite <- function(node, expr) {
+  # Defensive (parallels the unresolved-`named` guard in .rg_type): an `extends`
+  # node carries base = NULL until .ra_merge_extends resolves it. The roclet always
+  # resolves before generating, so this only fires on direct internal-API misuse.
+  if (is.null(node$base)) {
+    stop(
+      "roxyassert: internal error - a composite reached code generation with an ",
+      "unresolved base (an 'extends' must be resolved before generation)",
+      call. = FALSE
+    )
+  }
   checks <- sprintf("%s(%s)", .rg_composite_fn[[node$base]], expr)
   if (node$base == "list" && !is.null(node$element)) {
     el <- node$element

--- a/R/parse.R
+++ b/R/parse.R
@@ -27,8 +27,11 @@
 .ra_set_ok <- c(.ra_ordered_num, .ra_temporal, .ra_enumerable) # accept `in c(..)`
 .ra_na_ok <- c(.ra_ordered_num, .ra_temporal, .ra_enumerable, .ra_plain) # accept `| NA`
 
-# Built-in type words a @type name may not shadow.
-.ra_type_reserved <- c(.ra_atomic, .ra_composite, "any", "function", "class", "scalar", "vector", "promise")
+# Built-in type words and derivation keywords a @type name may not shadow.
+.ra_type_reserved <- c(
+  .ra_atomic, .ra_composite, "any", "function", "class", "scalar", "vector", "promise",
+  "extends", "pick", "omit"
+)
 
 # ---- cursor over the annotation text ----------------------------------------
 
@@ -530,6 +533,13 @@ parse_annotation <- function(text) {
 # same `named` path, so unknown-base and cycle detection are reused unchanged.
 .ra_merge_extends <- function(node, registry, stack) {
   bases <- node$extends
+  if (anyDuplicated(bases)) {
+    stop(
+      "roxyassert: 'extends' lists a base more than once: ",
+      paste(unique(bases[duplicated(bases)]), collapse = ", "),
+      call. = FALSE
+    )
+  }
   resolved <- lapply(bases, function(b) .ra_resolve_node(list(kind = "named", name = b), registry, stack))
   for (i in seq_along(resolved)) {
     b <- resolved[[i]]
@@ -554,19 +564,21 @@ parse_annotation <- function(text) {
   } else {
     character()
   }
-  # Inherited columns, in base order. A name in more than one base errors unless
-  # the child redeclares it (the override applied below resolves the tie).
+  dup_local <- unique(local_names[duplicated(local_names)])
+  if (length(dup_local) > 0L) {
+    stop("roxyassert: the derived type declares column '", dup_local[[1]], "' more than once", call. = FALSE)
+  }
+  # Inherited columns, in base order. A name in more than one base is RECORDED here
+  # but only errors LATER (after projection) if it survives and is not redeclared —
+  # so `extends A, B omit x` can resolve a collision by dropping the shared column.
   inherited <- list()
   seen <- character()
+  dup <- character()
   for (b in resolved) {
     for (f in b$fields) {
       if (f$name %in% seen) {
-        if (!(f$name %in% local_names)) {
-          stop(
-            "roxyassert: column '", f$name, "' is defined by more than one base; ",
-            "redeclare it in the derived type to resolve the conflict",
-            call. = FALSE
-          )
+        if (!(f$name %in% dup)) {
+          dup <- c(dup, f$name)
         }
         next
       }
@@ -574,8 +586,8 @@ parse_annotation <- function(text) {
       inherited[[length(inherited) + 1L]] <- f
     }
   }
-  # pick / omit projection over the inherited columns (mutually exclusive; every
-  # named column must exist in a base).
+  # pick / omit projection over the inherited columns (mutually exclusive — also
+  # guarded at parse time; every named column must exist in a base).
   if (!is.null(node$pick) && !is.null(node$omit)) {
     stop("roxyassert: 'pick' and 'omit' cannot both be used on one 'extends'", call. = FALSE)
   }
@@ -593,8 +605,20 @@ parse_annotation <- function(text) {
     }
     inherited <- Filter(function(f) !(f$name %in% node$omit), inherited)
   }
+  # A multi-base collision that SURVIVED projection and is not redeclared locally is
+  # unresolved -> error (drop it with pick/omit, or redeclare it).
+  retained <- vapply(inherited, function(f) f$name, character(1))
+  unresolved <- setdiff(intersect(dup, retained), local_names)
+  if (length(unresolved) > 0L) {
+    stop(
+      "roxyassert: column '", unresolved[[1]], "' is defined by more than one base; ",
+      "redeclare it in the derived type (or pick/omit it) to resolve the conflict",
+      call. = FALSE
+    )
+  }
   # Local field bullets: override an inherited column IN PLACE (keeping its
-  # position), or append a genuinely new column.
+  # position), or append a genuinely NEW column. Redeclaring a base column that
+  # pick/omit removed is contradictory -> error.
   fields <- inherited
   if (length(node$fields) > 0L) {
     for (lf in node$fields) {
@@ -602,6 +626,12 @@ parse_annotation <- function(text) {
       idx <- match(lf$name, pos)
       if (!is.na(idx)) {
         fields[[idx]] <- lf
+      } else if (lf$name %in% seen) {
+        stop(
+          "roxyassert: column '", lf$name, "' was excluded by pick/omit but is ",
+          "redeclared; drop it from pick/omit, or remove the bullet",
+          call. = FALSE
+        )
       } else {
         fields[[length(fields) + 1L]] <- lf
       }
@@ -673,6 +703,11 @@ parse_annotation <- function(text) {
   if (w %in% .ra_composite) {
     element <- NULL
     .ra_ws(p)
+    if (.ra_peek_word(p) == "extends") {
+      .ra_err(p, paste0(
+        "the kind is inherited from the base - write '(extends Base)', not '(", w, " extends Base)'"
+      ))
+    }
     if (w == "list" && .ra_ch(p) == "<") {
       p$pos <- p$pos + 1L
       element <- .ra_parse_type(p)
@@ -710,30 +745,36 @@ parse_annotation <- function(text) {
 # bases are not yet resolvable here). Field bullets (column additions / overrides)
 # attach as `$fields` through the normal bullet path, exactly like a bare composite.
 .ra_parse_extends <- function(p) {
-  bases <- .ra_read_name_list(p)
+  bases <- .ra_read_name_list(p, "a base name after 'extends'")
   pick <- NULL
   omit <- NULL
   proj <- .ra_peek_word(p)
   if (proj == "pick" || proj == "omit") {
     .ra_read_word(p)
-    cols <- .ra_read_name_list(p)
+    cols <- .ra_read_name_list(p, paste0("a column name after '", proj, "'"))
     if (proj == "pick") {
       pick <- cols
     } else {
       omit <- cols
+    }
+    # Only one projection per derivation: a second pick/omit is an explicit error
+    # (rather than the opaque "trailing input" the leftover would otherwise give).
+    nxt <- .ra_peek_word(p)
+    if (nxt == "pick" || nxt == "omit") {
+      .ra_err(p, "'pick' and 'omit' cannot both be used on one 'extends'")
     }
   }
   return(list(kind = "composite", base = NULL, extends = bases, pick = pick, omit = omit, element = NULL, fields = NULL))
 }
 
 # A comma-separated list of identifiers: the base name(s) after `extends`, or the
-# column names after `pick` / `omit`.
-.ra_read_name_list <- function(p) {
+# column names after `pick` / `omit`. `what` names what is expected, for the error.
+.ra_read_name_list <- function(p, what) {
   names <- character()
   repeat {
     nm <- .ra_read_word(p)
     if (nm == "") {
-      .ra_err(p, "expected a name")
+      .ra_err(p, paste0("expected ", what))
     }
     names <- c(names, nm)
     .ra_ws(p)

--- a/R/parse.R
+++ b/R/parse.R
@@ -506,6 +506,9 @@ parse_annotation <- function(text) {
     }
     return(.ra_resolve_node(registry[[nm]], registry, c(stack, nm)))
   }
+  if (!is.null(node$extends)) {
+    node <- .ra_merge_extends(node, registry, stack)
+  }
   if (!is.null(node$element)) {
     node$element <- .ra_resolve_node(node$element, registry, stack)
   }
@@ -518,12 +521,110 @@ parse_annotation <- function(text) {
   return(node)
 }
 
+# Resolve a DERIVED composite (an `extends` node): splice each base's columns with
+# this node's local field bullets (additions / overrides) and any pick/omit
+# projection, yielding a plain composite (kind + ordered fields) that the generator
+# lowers exactly like a hand-written record. The kind is inherited from the
+# base(s); a column defined by more than one base is an error unless the child
+# redeclares it (its override then resolves the tie). Bases resolve through the
+# same `named` path, so unknown-base and cycle detection are reused unchanged.
+.ra_merge_extends <- function(node, registry, stack) {
+  bases <- node$extends
+  resolved <- lapply(bases, function(b) .ra_resolve_node(list(kind = "named", name = b), registry, stack))
+  for (i in seq_along(resolved)) {
+    b <- resolved[[i]]
+    if (!identical(b$kind, "composite") || !is.null(b$element)) {
+      stop(
+        "roxyassert: 'extends ", bases[[i]], "': a base must be a record type ",
+        "(list / data.table / data.frame with columns)",
+        call. = FALSE
+      )
+    }
+  }
+  kinds <- unique(vapply(resolved, function(b) b$base, character(1)))
+  if (length(kinds) > 1L) {
+    stop(
+      "roxyassert: 'extends' bases have mixed kinds (", paste(kinds, collapse = ", "),
+      "); all bases must be the same composite kind",
+      call. = FALSE
+    )
+  }
+  local_names <- if (length(node$fields) > 0L) {
+    vapply(node$fields, function(f) f$name, character(1))
+  } else {
+    character()
+  }
+  # Inherited columns, in base order. A name in more than one base errors unless
+  # the child redeclares it (the override applied below resolves the tie).
+  inherited <- list()
+  seen <- character()
+  for (b in resolved) {
+    for (f in b$fields) {
+      if (f$name %in% seen) {
+        if (!(f$name %in% local_names)) {
+          stop(
+            "roxyassert: column '", f$name, "' is defined by more than one base; ",
+            "redeclare it in the derived type to resolve the conflict",
+            call. = FALSE
+          )
+        }
+        next
+      }
+      seen <- c(seen, f$name)
+      inherited[[length(inherited) + 1L]] <- f
+    }
+  }
+  # pick / omit projection over the inherited columns (mutually exclusive; every
+  # named column must exist in a base).
+  if (!is.null(node$pick) && !is.null(node$omit)) {
+    stop("roxyassert: 'pick' and 'omit' cannot both be used on one 'extends'", call. = FALSE)
+  }
+  if (!is.null(node$pick)) {
+    unknown <- setdiff(node$pick, seen)
+    if (length(unknown) > 0L) {
+      stop("roxyassert: 'pick' names a column not in the base(s): ", paste(unknown, collapse = ", "), call. = FALSE)
+    }
+    inherited <- Filter(function(f) f$name %in% node$pick, inherited)
+  }
+  if (!is.null(node$omit)) {
+    unknown <- setdiff(node$omit, seen)
+    if (length(unknown) > 0L) {
+      stop("roxyassert: 'omit' names a column not in the base(s): ", paste(unknown, collapse = ", "), call. = FALSE)
+    }
+    inherited <- Filter(function(f) !(f$name %in% node$omit), inherited)
+  }
+  # Local field bullets: override an inherited column IN PLACE (keeping its
+  # position), or append a genuinely new column.
+  fields <- inherited
+  if (length(node$fields) > 0L) {
+    for (lf in node$fields) {
+      pos <- vapply(fields, function(f) f$name, character(1))
+      idx <- match(lf$name, pos)
+      if (!is.na(idx)) {
+        fields[[idx]] <- lf
+      } else {
+        fields[[length(fields) + 1L]] <- lf
+      }
+    }
+  }
+  node$base <- kinds[[1]]
+  node$fields <- fields
+  node$extends <- NULL
+  node$pick <- NULL
+  node$omit <- NULL
+  return(node)
+}
+
 # ---- type --------------------------------------------------------------------
 
 .ra_parse_type <- function(p) {
   w <- .ra_read_word(p)
   if (w == "") {
     .ra_err(p, "expected a type")
+  }
+
+  if (w == "extends") {
+    return(.ra_parse_extends(p))
   }
 
   if (w == "scalar" || w == "vector") {
@@ -601,6 +702,48 @@ parse_annotation <- function(text) {
   # generation) reports it as an unknown type. A named type takes no in/| NA — it
   # stands for its whole definition (refine in the @type, not at the use site).
   return(list(kind = "named", name = w))
+}
+
+# `extends Base ( , Base )* ( (pick|omit) col ( , col )* )?` — a DERIVED composite.
+# Parse-time we capture only the base name(s) and any pick/omit projection; the
+# base kind and inherited columns are spliced in later by .ra_merge_extends (the
+# bases are not yet resolvable here). Field bullets (column additions / overrides)
+# attach as `$fields` through the normal bullet path, exactly like a bare composite.
+.ra_parse_extends <- function(p) {
+  bases <- .ra_read_name_list(p)
+  pick <- NULL
+  omit <- NULL
+  proj <- .ra_peek_word(p)
+  if (proj == "pick" || proj == "omit") {
+    .ra_read_word(p)
+    cols <- .ra_read_name_list(p)
+    if (proj == "pick") {
+      pick <- cols
+    } else {
+      omit <- cols
+    }
+  }
+  return(list(kind = "composite", base = NULL, extends = bases, pick = pick, omit = omit, element = NULL, fields = NULL))
+}
+
+# A comma-separated list of identifiers: the base name(s) after `extends`, or the
+# column names after `pick` / `omit`.
+.ra_read_name_list <- function(p) {
+  names <- character()
+  repeat {
+    nm <- .ra_read_word(p)
+    if (nm == "") {
+      .ra_err(p, "expected a name")
+    }
+    names <- c(names, nm)
+    .ra_ws(p)
+    if (.ra_ch(p) == ",") {
+      p$pos <- p$pos + 1L
+      next
+    }
+    break
+  }
+  return(names)
 }
 
 # Inside scalar<...> / vector<...>: an atom or the `any` wildcard.

--- a/README.Rmd
+++ b/README.Rmd
@@ -367,6 +367,58 @@ A `@type` resolves at `document()` time by **inline expansion** — the generate
 
 Rules: a `@type` defines a *single type* — add `?` / `| NULL` / unions at the **use site**, not the definition; references work bare, nullable, in a union, and inside `list<…>` / `promise<…>`, but not inside `scalar<>` / `vector<>` (define a scalar alias directly, like `Bps`). Types are package-local.
 
+### Deriving one type from another — `extends`, override, `pick` / `omit`
+
+A record type can be **built from another** instead of being copied — the same idea as TypeScript's `interface B extends A` and `Pick` / `Omit`.
+
+> **One rule for the parentheses:** the parentheses always mean *"this is a type."* `extends` lives **inside** them, and the kind (`data.table` / `list` / `data.frame`) is **inherited from the base** — never restated. There is no second syntax to remember.
+
+**Inherit and add columns** — write `extends Base`, then list only the *new* columns as bullets:
+
+```r
+#' @type Order (data.table):
+#' - order_id (character) the exchange id.
+#' - status (character in unlist(ORDER_STATUS)) lifecycle state.
+#' ... (defined once)
+
+#' @type OrderModifyResult (extends Order):
+#' - order_id_old (character) the id before the change.
+#' - order_id_new (character) the id after the change.
+```
+
+`OrderModifyResult` is every `Order` column **plus** the two new ones, in order — with no duplicated definition to drift.
+
+**Override a column** — redeclare it by name; the redeclaration replaces the inherited one *in place* (its position is kept). This is a trusted full replacement: roxyassert is a generator, not a type checker, so it does not verify the new type is a narrowing of the old.
+
+```r
+#' @type ClosedOrder (extends Order):
+#' - status (character in unlist(c("FILLED", "CANCELLED", "EXPIRED")))
+```
+
+**Multiple inheritance** — list several bases (all must be the same kind). A column defined by more than one base is an **error unless the derived type redeclares it** (the override then resolves the tie):
+
+```r
+#' @type MarginOrder (extends Order, MarginFields):
+```
+
+**Subset with `pick` / `omit`** (mutually exclusive; every named column must exist in a base):
+
+```r
+#' @type OrderSummary (extends Order pick order_id, status):
+#' @type PublicOrder  (extends Order omit order_id_client):
+```
+
+All of this works **inline** too — define the shape right in a `@param` / `@return`, no name needed:
+
+```r
+#' @param legs (extends Order pick order_id, status) the legs.
+#' @return (extends Order):
+#' - order_id_old (character) prior id.
+#' - order_id_new (character) new id.
+```
+
+Derivation is pure `document()`-time list algebra over the resolved columns: it reuses the existing `@type` registry, cycle / unknown-base detection, and lowering, with no runtime cost. Two derivations are deliberately **out of scope** for now (each is a separate, larger feature): *renaming* a column (use `omit` + re-add) and *generic / parameterized* types (`Paged<T>`).
+
 ## Standalone, exportable asserts — `@genassert` / `@exportassert`
 
 By default a `@type` only materialises as **inlined** checks inside a `@param`/`@return` that references it — so a shape used by no function (or one built internally and never passed as an argument) has no callable validator. Two tags lift that:
@@ -410,6 +462,7 @@ Things deliberately not supported yet — each is rejected with a clear error, a
 - **Refining a named type at the use site** — once `@type Price (scalar<numeric>)` is defined you can't write `(Price in [0, 1])`; the refinement must live in the definition (define a second `@type`, or write the refined type inline). Named types are also package-local (no cross-package reuse yet).
 - **A named type shows as its bare name in rendered docs** — `@type` is resolved only for the generated checks, so a help page / pkgdown site shows `(OrderAck)` verbatim, not its expanded shape, with no auto-generated topic or link. To give a type a help page, document its `@type` block like any object (add a title/description and `@name`); reference it as a markdown link (`[OrderAck]`) for a clickable cross-reference. (Auto-generated type pages and links may come later.)
 - **A `class<Name>` name is not verified at `document()` time** — roxyassert emits `assert_class(x, "Name")` blindly, so a typo such as `class<Duraton>` generates without complaint and fails only at runtime.
+- **An `extends` override is not checked for compatibility** — redeclaring an inherited column replaces it with whatever you write; roxyassert has no subtype lattice, so it does not verify the override narrows the base column (it trusts the author). Column *renaming* and *generic / parameterized* types (`Paged<T>`) are likewise not supported yet.
 
 ## Status
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -395,7 +395,7 @@ A record type can be **built from another** instead of being copied — the same
 #' - status (character in unlist(c("FILLED", "CANCELLED", "EXPIRED")))
 ```
 
-**Multiple inheritance** — list several bases (all must be the same kind). A column defined by more than one base is an **error unless the derived type redeclares it** (the override then resolves the tie):
+**Multiple inheritance** — list several bases (all must be the same kind). A column defined by more than one base is an **error unless you resolve it** — either redeclare it (the override wins) or drop it with `pick`/`omit`:
 
 ```r
 #' @type MarginOrder (extends Order, MarginFields):
@@ -407,6 +407,8 @@ A record type can be **built from another** instead of being copied — the same
 #' @type OrderSummary (extends Order pick order_id, status):
 #' @type PublicOrder  (extends Order omit order_id_client):
 ```
+
+`pick`/`omit` act on the **inherited** columns; redeclaring a column you just removed is an error. The keywords `extends` / `pick` / `omit` cannot be used as `@type` names, and listing a base or column twice is an error.
 
 All of this works **inline** too — define the shape right in a `@param` / `@return`, no name needed:
 

--- a/README.md
+++ b/README.md
@@ -536,8 +536,9 @@ does not verify the new type is a narrowing of the old.
 ```
 
 **Multiple inheritance** — list several bases (all must be the same
-kind). A column defined by more than one base is an **error unless the
-derived type redeclares it** (the override then resolves the tie):
+kind). A column defined by more than one base is an **error unless you
+resolve it** — either redeclare it (the override wins) or drop it with
+`pick`/`omit`:
 
 ``` r
 #' @type MarginOrder (extends Order, MarginFields):
@@ -550,6 +551,11 @@ must exist in a base):
 #' @type OrderSummary (extends Order pick order_id, status):
 #' @type PublicOrder  (extends Order omit order_id_client):
 ```
+
+`pick`/`omit` act on the **inherited** columns; redeclaring a column you
+just removed is an error. The keywords `extends` / `pick` / `omit`
+cannot be used as `@type` names, and listing a base or column twice is
+an error.
 
 All of this works **inline** too — define the shape right in a `@param`
 / `@return`, no name needed:

--- a/README.md
+++ b/README.md
@@ -497,6 +497,77 @@ in a union, and inside `list<…>` / `promise<…>`, but not inside
 `scalar<>` / `vector<>` (define a scalar alias directly, like `Bps`).
 Types are package-local.
 
+### Deriving one type from another — `extends`, override, `pick` / `omit`
+
+A record type can be **built from another** instead of being copied —
+the same idea as TypeScript’s `interface B extends A` and `Pick` /
+`Omit`.
+
+> **One rule for the parentheses:** the parentheses always mean *“this
+> is a type.”* `extends` lives **inside** them, and the kind
+> (`data.table` / `list` / `data.frame`) is **inherited from the base**
+> — never restated. There is no second syntax to remember.
+
+**Inherit and add columns** — write `extends Base`, then list only the
+*new* columns as bullets:
+
+``` r
+#' @type Order (data.table):
+#' - order_id (character) the exchange id.
+#' - status (character in unlist(ORDER_STATUS)) lifecycle state.
+#' ... (defined once)
+
+#' @type OrderModifyResult (extends Order):
+#' - order_id_old (character) the id before the change.
+#' - order_id_new (character) the id after the change.
+```
+
+`OrderModifyResult` is every `Order` column **plus** the two new ones,
+in order — with no duplicated definition to drift.
+
+**Override a column** — redeclare it by name; the redeclaration replaces
+the inherited one *in place* (its position is kept). This is a trusted
+full replacement: roxyassert is a generator, not a type checker, so it
+does not verify the new type is a narrowing of the old.
+
+``` r
+#' @type ClosedOrder (extends Order):
+#' - status (character in unlist(c("FILLED", "CANCELLED", "EXPIRED")))
+```
+
+**Multiple inheritance** — list several bases (all must be the same
+kind). A column defined by more than one base is an **error unless the
+derived type redeclares it** (the override then resolves the tie):
+
+``` r
+#' @type MarginOrder (extends Order, MarginFields):
+```
+
+**Subset with `pick` / `omit`** (mutually exclusive; every named column
+must exist in a base):
+
+``` r
+#' @type OrderSummary (extends Order pick order_id, status):
+#' @type PublicOrder  (extends Order omit order_id_client):
+```
+
+All of this works **inline** too — define the shape right in a `@param`
+/ `@return`, no name needed:
+
+``` r
+#' @param legs (extends Order pick order_id, status) the legs.
+#' @return (extends Order):
+#' - order_id_old (character) prior id.
+#' - order_id_new (character) new id.
+```
+
+Derivation is pure `document()`-time list algebra over the resolved
+columns: it reuses the existing `@type` registry, cycle / unknown-base
+detection, and lowering, with no runtime cost. Two derivations are
+deliberately **out of scope** for now (each is a separate, larger
+feature): *renaming* a column (use `omit` + re-add) and *generic /
+parameterized* types (`Paged<T>`).
+
 ## Standalone, exportable asserts — `@genassert` / `@exportassert`
 
 By default a `@type` only materialises as **inlined** checks inside a
@@ -600,6 +671,12 @@ reference’s *Non-goals* section is the full formal list.)
   roxyassert emits `assert_class(x, "Name")` blindly, so a typo such as
   `class<Duraton>` generates without complaint and fails only at
   runtime.
+- **An `extends` override is not checked for compatibility** —
+  redeclaring an inherited column replaces it with whatever you write;
+  roxyassert has no subtype lattice, so it does not verify the override
+  narrows the base column (it trusts the author). Column *renaming* and
+  *generic / parameterized* types (`Paged<T>`) are likewise not
+  supported yet.
 
 ## Status
 

--- a/tests/testthat/test-extends.R
+++ b/tests/testthat/test-extends.R
@@ -1,0 +1,177 @@
+# Tests for @type record DERIVATION: `extends` (single / multiple inheritance),
+# override-by-redeclaration, and pick / omit projection — both as named @type
+# definitions and inline in @param / @return. End-to-end via the roclet
+# (proc_code), with a few parse/resolve unit checks.
+
+rt <- function(text) proc_code(text)
+err <- function(text) tryCatch(rt(text), error = function(e) conditionMessage(e))
+noref <- "#' F.\n#' @export\nf <- function() NULL"
+
+# A base record reused across cases.
+order <- "#' @type Order (data.table):\n#' - id (character) the id.\n#' - status (character) the state.\n"
+
+# ---- inherit + add ----------------------------------------------------------
+
+test_that("extends inherits the base columns and appends new ones, in order", {
+  text <- paste0(
+    order,
+    "NULL\n",
+    "#' @type OrderMod (extends Order):\n#' - old (character) prior id.\n#' - new (character) new id.\nNULL\n",
+    "#' F.\n#' @return (OrderMod) x.\n#' @export\nf <- function() NULL"
+  )
+  code <- rt(text)
+  expect_true(any(grepl('assert_data_table\\(value\\)', code)))
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("id", "status", "old", "new"\\)\\)', code)))
+  # an inherited column keeps its own check
+  expect_true(any(grepl('assert_character\\(value\\[\\["id"\\]\\]\\)', code)))
+  # a new column is checked too
+  expect_true(any(grepl('assert_character\\(value\\[\\["new"\\]\\]\\)', code)))
+})
+
+test_that("a bare extends (no new columns) is an alias for the base", {
+  text <- paste0(order, "NULL\n", "#' @type OrderCopy (extends Order)\nNULL\n",
+    "#' F.\n#' @return (OrderCopy) x.\n#' @export\nf <- function() NULL")
+  code <- rt(text)
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("id", "status"\\)\\)', code)))
+})
+
+# ---- override ---------------------------------------------------------------
+
+test_that("redeclaring a column overrides it in place (position kept, type changed)", {
+  text <- paste0(
+    order, "NULL\n",
+    "#' @type OrderI (extends Order):\n#' - status (integer) numeric state.\nNULL\n",
+    "#' F.\n#' @return (OrderI) x.\n#' @export\nf <- function() NULL"
+  )
+  code <- rt(text)
+  # still two columns, status still in second position
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("id", "status"\\)\\)', code)))
+  # status now lowers to the integer check, not character
+  expect_true(any(grepl('assert_integer\\(value\\[\\["status"\\]\\]\\)', code)))
+  expect_false(any(grepl('assert_character\\(value\\[\\["status"\\]\\]\\)', code)))
+})
+
+# ---- multiple inheritance ---------------------------------------------------
+
+test_that("extends merges columns from several bases", {
+  text <- paste0(
+    "#' @type A (data.table):\n#' - a (character) x.\nNULL\n",
+    "#' @type B (data.table):\n#' - b (numeric) y.\nNULL\n",
+    "#' @type C (extends A, B):\n#' - c (logical) z.\nNULL\n",
+    "#' F.\n#' @return (C) x.\n#' @export\nf <- function() NULL"
+  )
+  code <- rt(text)
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("a", "b", "c"\\)\\)', code)))
+})
+
+test_that("a column shared by two bases errors unless the child redeclares it", {
+  defs <- paste0(
+    "#' @type A (data.table):\n#' - x (character) ax.\nNULL\n",
+    "#' @type B (data.table):\n#' - x (numeric) bx.\nNULL\n"
+  )
+  # unresolved collision
+  bad <- paste0(defs, "#' @type C (extends A, B)\nNULL\n", noref)
+  expect_match(err(bad), "defined by more than one base")
+  # resolved by an override in the child
+  good <- paste0(defs, "#' @type C (extends A, B):\n#' - x (logical) cx.\nNULL\n",
+    "#' F.\n#' @return (C) x.\n#' @export\nf <- function() NULL")
+  code <- rt(good)
+  expect_true(any(grepl('assert_logical\\(value\\[\\["x"\\]\\]\\)', code)))
+})
+
+test_that("bases of different kinds error", {
+  defs <- paste0(
+    "#' @type L (list):\n#' - a (character) x.\nNULL\n",
+    "#' @type T (data.table):\n#' - b (numeric) y.\nNULL\n"
+  )
+  expect_match(err(paste0(defs, "#' @type X (extends L, T)\nNULL\n", noref)), "mixed kinds")
+})
+
+# ---- pick / omit ------------------------------------------------------------
+
+test_that("pick keeps only the named columns; omit drops them", {
+  text <- paste0(
+    order, "NULL\n",
+    "#' @type OnlyId (extends Order pick id)\nNULL\n",
+    "#' @type NoStatus (extends Order omit status)\nNULL\n",
+    "#' F.\n#' @param a (OnlyId) one.\n#' @return (NoStatus) two.\n#' @export\nf <- function(a) NULL"
+  )
+  code <- rt(text)
+  expect_true(any(grepl('assert_has_columns\\(a, c\\("id"\\)\\)', code)))
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("id"\\)\\)', code)))
+})
+
+test_that("pick/omit error on an unknown column or when used together", {
+  base <- paste0(order, "NULL\n")
+  expect_match(err(paste0(base, "#' @type P (extends Order pick nope)\nNULL\n", noref)), "pick.*not in the base")
+  expect_match(err(paste0(base, "#' @type O (extends Order omit nope)\nNULL\n", noref)), "omit.*not in the base")
+  # pick and omit on one head: only the first projection parses, the rest is
+  # unexpected trailing input -> error (you cannot use both).
+  both <- paste0(base, "#' @type PO (extends Order pick id omit status)\nNULL\n", noref)
+  expect_error(rt(both))
+})
+
+# ---- errors: unknown base, cycle, non-composite -----------------------------
+
+test_that("extends errors: unknown base, cycle, non-record base", {
+  expect_match(err(paste0("#' @type D (extends Nope)\nNULL\n", noref)), "unknown type")
+  expect_match(err(paste0(
+    "#' @type A (extends B):\n#' - a (character) x.\nNULL\n",
+    "#' @type B (extends A):\n#' - b (character) y.\nNULL\n", noref
+  )), "cyclic")
+  expect_match(err(paste0(
+    "#' @type Sc (scalar<numeric>)\nNULL\n",
+    "#' @type D (extends Sc)\nNULL\n", noref
+  )), "must be a record type")
+})
+
+# ---- transitive -------------------------------------------------------------
+
+test_that("a derived type can itself be extended (transitive)", {
+  text <- paste0(
+    order, "NULL\n",
+    "#' @type A (extends Order):\n#' - a (character) x.\nNULL\n",
+    "#' @type B (extends A):\n#' - b (character) y.\nNULL\n",
+    "#' F.\n#' @return (B) x.\n#' @export\nf <- function() NULL"
+  )
+  code <- rt(text)
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("id", "status", "a", "b"\\)\\)', code)))
+})
+
+# ---- inline derivation ------------------------------------------------------
+
+test_that("extends works inline in @return and @param (no name needed)", {
+  text <- paste0(
+    order, "NULL\n",
+    "#' F.\n",
+    "#' @param legs (extends Order pick id) the legs.\n",
+    "#' @return (extends Order):\n#' - extra (character) bonus.\n",
+    "#' @export\nf <- function(legs) NULL"
+  )
+  code <- rt(text)
+  expect_true(any(grepl('assert_has_columns\\(legs, c\\("id"\\)\\)', code)))
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("id", "status", "extra"\\)\\)', code)))
+})
+
+# ---- @genassert on a derived type -------------------------------------------
+
+test_that("@genassert builds a standalone validator for a derived @type", {
+  text <- paste0(
+    order, "NULL\n",
+    "#' @type OrderMod (extends Order):\n#' - old (character) prior.\n#' @genassert\nNULL"
+  )
+  code <- rt(text)
+  expect_true(any(grepl('^assert_type_OrderMod <- function\\(value\\)', code)))
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("id", "status", "old"\\)\\)', code)))
+})
+
+# ---- parse-level units ------------------------------------------------------
+
+test_that("parse_annotation captures extends, pick and omit", {
+  d <- parse_annotation("(extends Order)")$alternatives[[1]]
+  expect_equal(d$kind, "composite")
+  expect_equal(d$extends, "Order")
+  expect_equal(parse_annotation("(extends A, B)")$alternatives[[1]]$extends, c("A", "B"))
+  expect_equal(parse_annotation("(extends Order pick id, status)")$alternatives[[1]]$pick, c("id", "status"))
+  expect_equal(parse_annotation("(extends Order omit status)")$alternatives[[1]]$omit, "status")
+})

--- a/tests/testthat/test-extends.R
+++ b/tests/testthat/test-extends.R
@@ -105,10 +105,9 @@ test_that("pick/omit error on an unknown column or when used together", {
   base <- paste0(order, "NULL\n")
   expect_match(err(paste0(base, "#' @type P (extends Order pick nope)\nNULL\n", noref)), "pick.*not in the base")
   expect_match(err(paste0(base, "#' @type O (extends Order omit nope)\nNULL\n", noref)), "omit.*not in the base")
-  # pick and omit on one head: only the first projection parses, the rest is
-  # unexpected trailing input -> error (you cannot use both).
+  # pick and omit on one head -> dedicated error (you cannot use both).
   both <- paste0(base, "#' @type PO (extends Order pick id omit status)\nNULL\n", noref)
-  expect_error(rt(both))
+  expect_match(err(both), "cannot both be used")
 })
 
 # ---- errors: unknown base, cycle, non-composite -----------------------------
@@ -174,4 +173,114 @@ test_that("parse_annotation captures extends, pick and omit", {
   expect_equal(parse_annotation("(extends A, B)")$alternatives[[1]]$extends, c("A", "B"))
   expect_equal(parse_annotation("(extends Order pick id, status)")$alternatives[[1]]$pick, c("id", "status"))
   expect_equal(parse_annotation("(extends Order omit status)")$alternatives[[1]]$omit, "status")
+})
+
+# ---- pick/omit vs multi-base collisions -------------------------------------
+
+test_that("pick/omit can resolve a multi-base collision; an unresolved one still errors", {
+  defs <- paste0(
+    "#' @type A (data.table):\n#' - x (character) ax.\n#' - y (character) ay.\nNULL\n",
+    "#' @type B (data.table):\n#' - x (numeric) bx.\n#' - z (numeric) bz.\nNULL\n"
+  )
+  ret <- "#' F.\n#' @return (C) v.\n#' @export\nf <- function() NULL"
+  # omit the colliding column -> succeeds with the rest
+  expect_true(any(grepl(
+    'assert_has_columns\\(value, c\\("y", "z"\\)\\)',
+    rt(paste0(defs, "#' @type C (extends A, B omit x)\nNULL\n", ret))
+  )))
+  # pick a non-colliding subset -> succeeds
+  expect_true(any(grepl(
+    'assert_has_columns\\(value, c\\("y", "z"\\)\\)',
+    rt(paste0(defs, "#' @type C (extends A, B pick y, z)\nNULL\n", ret))
+  )))
+  # a collision NOT removed by the projection still errors
+  expect_match(err(paste0(defs, "#' @type C (extends A, B pick x, y)\nNULL\n", noref)), "more than one base")
+})
+
+test_that("override resolving a collision keeps the inherited position", {
+  defs <- paste0(
+    "#' @type A (data.table):\n#' - x (character) ax.\n#' - y (character) ay.\nNULL\n",
+    "#' @type B (data.table):\n#' - x (numeric) bx.\n#' - z (numeric) bz.\nNULL\n"
+  )
+  code <- rt(paste0(defs, "#' @type C (extends A, B):\n#' - x (logical) cx.\nNULL\n",
+    "#' F.\n#' @return (C) v.\n#' @export\nf <- function() NULL"))
+  # x keeps first (A's) position; columns x, y, z; x now logical
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("x", "y", "z"\\)\\)', code)))
+  expect_true(any(grepl('assert_logical\\(value\\[\\["x"\\]\\]\\)', code)))
+})
+
+# ---- richer column types in derived records ---------------------------------
+
+test_that("a derived record can inherit/add list<T> and nullable columns", {
+  text <- paste0(
+    "#' @type Base (data.table):\n#' - id (character) id.\n#' - note (character?) optional.\nNULL\n",
+    "#' @type Tagged (extends Base):\n#' - tags (list<character>) a list-column.\nNULL\n",
+    "#' F.\n#' @return (Tagged?) maybe.\n#' @export\nf <- function() NULL"
+  )
+  code <- rt(text)
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("id", "note", "tags"\\)\\)', code)))
+  expect_true(any(grepl('assert_list_of\\(value\\[\\["tags"\\]\\], "character"\\)', code)))
+  # nullable derived return wraps the whole expansion
+  expect_true(any(grepl('if \\(!is.null\\(value\\)\\)', code)))
+  # the inherited nullable column wraps its own check
+  expect_true(any(grepl('if \\(!is.null\\(value\\[\\["note"\\]\\]\\)\\)', code)))
+})
+
+test_that("a derived type works inside list<> and promise<>", {
+  text <- paste0(
+    order, "NULL\n",
+    "#' @type Mod (extends Order):\n#' - old (character) prior.\nNULL\n",
+    "#' F.\n#' @param xs (list<Mod>) many.\n#' @return (promise<Mod>) async one.\n#' @export\nf <- function(xs) NULL"
+  )
+  code <- rt(text)
+  expect_true(any(grepl('assert_list\\(xs\\)', code)))
+  expect_true(any(grepl('for \\(.x in xs\\)', code)))
+  # promise<Mod> validates the resolved record
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("id", "status", "old"\\)\\)', code)))
+})
+
+test_that("extends works inline in an R6 method @return", {
+  text <- paste0(order, "NULL\n", "
+    #' @title Engine
+    #' @description An engine.
+    Engine <- R6::R6Class('Engine',
+      public = list(
+        #' @description Modify an order.
+        #' @return (extends Order):
+        #' - extra (character) bonus.
+        modify = function() NULL
+      )
+    )
+  ")
+  code <- rt(text)
+  expect_true(any(grepl('^assert_return_Engine__modify <- function\\(value\\)', code)))
+  expect_true(any(grepl('assert_has_columns\\(value, c\\("id", "status", "extra"\\)\\)', code)))
+})
+
+# ---- more error paths -------------------------------------------------------
+
+test_that("derivation rejects malformed forms with clear errors", {
+  base <- paste0(order, "NULL\n")
+  # duplicate base
+  expect_match(err(paste0(base, "#' @type D (extends Order, Order)\nNULL\n", noref)), "more than once")
+  # duplicate local column
+  expect_match(err(paste0(base,
+    "#' @type D (extends Order):\n#' - new (character) a.\n#' - new (integer) b.\nNULL\n", noref)), "more than once")
+  # restating the inherited kind
+  expect_match(err(paste0(base, "#' @type D (data.table extends Order)\nNULL\n", noref)), "inherited from the base")
+  # redeclaring a column that pick/omit removed
+  expect_match(err(paste0(base,
+    "#' @type D (extends Order omit status):\n#' - status (integer) s.\nNULL\n", noref)), "excluded by pick/omit")
+  # a derivation keyword cannot be a @type name
+  expect_match(err(paste0("#' @type extends (data.table):\n#' - a (character) x.\nNULL\n", noref)), "shadow")
+})
+
+test_that("@noassert suppresses a derived-typed parameter's check", {
+  text <- paste0(
+    order, "NULL\n",
+    "#' @type Mod (extends Order):\n#' - old (character) prior.\nNULL\n",
+    "#' F.\n#' @param m (Mod) the mod.\n#' @noassert m\n#' @export\nf <- function(m) NULL"
+  )
+  code <- rt(text)
+  expect_false(any(grepl('assert_has_columns\\(m,', code)))
 })

--- a/vignettes/grammar.Rmd
+++ b/vignettes/grammar.Rmd
@@ -394,8 +394,13 @@ These context-sensitive constraints are checked by the generator; they are
   than one base** is an error **unless** the derived type redeclares it (the
   override resolves the tie). `pick` keeps only the listed inherited columns,
   `omit` drops them; the two are **mutually exclusive** and every listed name must
-  exist in a base. Bases resolve through `named` (S6), so an **unknown base** and a
-  **cycle** reuse S6's detection. Works in a `@type` definition and **inline** in a
+  exist in a base. The collision check runs **after** `pick`/`omit`, so dropping a
+  shared column with `pick`/`omit` also resolves the conflict; conversely,
+  redeclaring a column that `pick`/`omit` removed is an error. Listing a **base**
+  twice, declaring a **column** twice, or restating the kind (`data.table extends
+  …`) are errors, and the keywords `extends`/`pick`/`omit` may not be `@type` names.
+  Bases resolve through `named` (S6), so an **unknown base** and a **cycle** reuse
+  S6's detection. Works in a `@type` definition and **inline** in a
   `@param`/`@return`. Column *renaming* and *generic / parameterized* types are out
   of scope (§12).
 

--- a/vignettes/grammar.Rmd
+++ b/vignettes/grammar.Rmd
@@ -112,7 +112,7 @@ slot           ::= type ( "|" type )*  ( ( "|" "NULL" ) | "?" )?
                       written EITHER as a "| NULL" alternative OR a trailing "?",
                       never both *)
 
-type           ::= atomic | wildcard | reference | composite | promise | named
+type           ::= atomic | wildcard | reference | composite | derived | promise | named
 named          ::= ident
                    (* an identifier that is not a built-in type: a reference to a
                       type declared elsewhere with `@type` (S6). Resolved inline at
@@ -154,6 +154,16 @@ composite      ::= "list" ( "<" type ">" )? | "data.table" | "data.frame"
                       list<class<Engine>>, list<any>, list<data.table>. T is a `type`
                       (no slot-level union / `| NULL` / `?`); a `list<T>` is a leaf
                       and takes no bullets (S1, S3). *)
+derived        ::= "extends" ident ( "," ident )*
+                       ( ( "pick" | "omit" ) ident ( "," ident )* )?
+                   (* a DERIVED composite (S7): inherit the columns of the named
+                      base record(s), then add / override columns via nested bullets
+                      and/or narrow with pick / omit. The composite KIND is inherited
+                      from the base(s) and never restated (no `data.table extends`);
+                      the whole derivation sits INSIDE the parentheses, like any
+                      type. Resolved at document() time by splicing columns; bases
+                      resolve through `named`, so cycle / unknown-base detection is
+                      reused. *)
 promise        ::= "promise" "<" type ">"
                    (* a result resolving to the type T, delivered synchronously
                       OR as a promises::promise (S5). T is a single `type` (no
@@ -276,6 +286,12 @@ Tokenizing rules (so the grammar is deterministic in practice):
   `(numeric | character | NA)` the `| NA` belongs to `character`. `| NULL` is not
   positional: the grammar fixes it to the slot tail, so a mid-union
   `(numeric | NULL | character)` is a parse error.
+- **`extends` name lists.** A slot opening with the keyword `extends` is a
+  `derived` composite: a comma-separated list of base `ident`s, then an optional
+  `pick`/`omit` keyword with its own comma-separated `ident` list of column names.
+  Both lists are plain identifiers (no brackets / `rexpr`); each ends at the first
+  token that is not `ident` `","`. Nested `bullets` after the `)` add or override
+  columns exactly as for a bare composite (S1).
 
 ## 4. Static rules (beyond the context-free grammar)
 
@@ -364,6 +380,24 @@ These context-sensitive constraints are checked by the generator; they are
   / bullets) — the shape lives only in the definition. A `@type` may reference another
   (resolved transitively); a **cycle**, an **unknown** name, a **duplicate** `@type`,
   and a name that **shadows a built-in** are all errors. Types are **package-local**.
+- **S7 — record derivation (`extends`).** A `derived` type splices the resolved
+  columns of its base(s) with this type's own field bullets and any `pick`/`omit`,
+  producing a plain composite that lowers exactly like a hand-written record (no
+  runtime cost). The composite **kind is inherited**: every base must resolve to a
+  bare composite (S3) and all bases must share one kind (mixing `list` with
+  `data.table` is an error); the derived type never restates the kind. **Inherited
+  columns come first, in base order**, then this type's added columns in source
+  order. A bullet whose name **matches** an inherited column **overrides it in
+  place** (its position is kept) — a *trusted full replacement*, **not** checked
+  for being a narrowing (roxyassert has no subtype lattice, so the author owns
+  compatibility). A bullet with a **new** name appends. A column defined by **more
+  than one base** is an error **unless** the derived type redeclares it (the
+  override resolves the tie). `pick` keeps only the listed inherited columns,
+  `omit` drops them; the two are **mutually exclusive** and every listed name must
+  exist in a base. Bases resolve through `named` (S6), so an **unknown base** and a
+  **cycle** reuse S6's detection. Works in a `@type` definition and **inline** in a
+  `@param`/`@return`. Column *renaming* and *generic / parameterized* types are out
+  of scope (§12).
 
 ## 5. Binding & precedence (why `|` is never ambiguous)
 
@@ -772,6 +806,14 @@ model objects are **no longer** here — they are now `list<T>`, e.g.
   the refinement in the `@type`, define another `@type`, or write the refined type
   inline. **Cross-package** named types are also out of scope — `@type` is
   package-local.
+- **Renaming a derived column** — a `derived` type (S7, `extends`) can add,
+  override, `pick` and `omit` columns, but cannot *rename* an inherited column
+  (there is no `old -> new` operator). Use `omit` + re-add under the new name. A
+  renamed column is, for assertion purposes, a different record.
+- **Generic / parameterized types** — a `@type` template over a type variable
+  (`@type Paged<T>` instantiated as `Paged<Order>`) is out of scope. The `<…>`
+  syntax only *applies* a known container (`list<T>`, `promise<T>`, `class<T>`) to a
+  concrete type; it does not *define* a type parameter.
 
 ## 13. `@noassert` — document a type without enforcing it
 
@@ -814,6 +856,7 @@ ticker = function(symbol) {
 - [ ] `vector<>` requires a length (`,` n / a..b / a..); a length-less `vector<T>` is rejected (use bare `T`); a length appears only inside `vector<>`; `scalar<T, n>` is rejected; `..` is one token, valid only in length position.
 - [ ] `function`/`class<Class>` appear only as bare reference types; `class` always names a single class (any object system; no `pkg::` qualifier — name the package in prose).
 - [ ] `list`/`data.table`/`data.frame` carry no `in`/`| NA`/length/`vector<>`; refined by nested bullets (named record / typed columns, S1/S3) **or**, for `list`, parameterised as `list<T>` where `T` is a single `type` (homogeneous, no slot-union/`| NULL`/`?`, a leaf with no bullets); `list<any>` ≡ bare `list` at runtime; a list-column is typed `list<T>`, and an atomic-typed column rejects list-cells.
+- [ ] a `derived` composite (`extends Base…`) sits inside the parentheses, inherits its kind from the base(s) (never restated), inherited columns first then added/overridden ones (override in place, trusted/unchecked), errors on a multi-base column collision unless redeclared, and `pick`/`omit` are mutually exclusive over existing base columns (S7).
 - [ ] everything after `)` is free-text description (roxyassert ignores it); a `:` adjacent to it is cosmetic; canonical style omits it.
 - [ ] `promise<T>` lowers to `T`'s checks with no `then()`/`is.promise()` emitted (the caller wires the async); `T | promise<T>` (same T) collapses to the resolved `T`, nested `promise<promise<T>>` collapses too, and a promise unioned with a *different* type is rejected; `promise<T>` is a whole-slot value, so it is rejected as a list element or inside `scalar<>`/`vector<>` (S5).
 - [ ] a bare identifier that is not a built-in type is a `@type` reference (S6), resolved inline to its definition; a `@type` is a single type (no use-site `?`/`|`/`| NULL` in the def), usable bare / nullable / unioned / inside `list<>`/`promise<>` but not inside `scalar<>`/`vector<>`, with no use-site refinement; unknown names, duplicates, built-in shadowing, and cycles are errors; package-local.


### PR DESCRIPTION
## What

Adds **record-type derivation** to the `@type` system — build one record shape from another instead of duplicating columns.

Operations (the full set; rename is deferred to #13, generics to #12):

| Operation | Syntax |
|---|---|
| inherit + add | `@type OrderModifyResult (extends Order):` + new column bullets |
| override a column | redeclare it in a bullet (trusted full replacement, position kept) |
| multiple inheritance | `(extends Order, MarginFields)` — collision = error unless redeclared |
| pick (subset) | `(extends Order pick order_id, status)` |
| omit (subset) | `(extends Order omit order_id_client)` |

Works both **named** (`@type ... (extends Base):`) and **inline** in `@param`/`@return`
(`@return (extends Order):` + bullets).

## Design philosophy

**Parentheses always mean "this is a type."** `extends` lives *inside* them, the kind
(`data.table`/`list`/`data.frame`) is inherited from the base and never restated.
One rule, no exceptions — documented in the README.

## How it works

- **Parse** (`R/parse.R`): `extends Base[, Base2] [pick|omit cols]` parses to a composite
  node carrying `$extends`; field bullets attach as `$fields` through the existing path.
- **Resolve** (`.ra_merge_extends`): splices base columns + local additions/overrides +
  pick/omit into a plain composite. Bases resolve through the existing `named` path, so
  unknown-base and cycle detection are reused unchanged.
- **Generate** (`R/generate.R`): **no change** — a merged node lowers exactly like a
  hand-written record.

## Checklist

- [x] Parser + resolver (`extends` / override / multiple / pick / omit)
- [ ] Tests (named + inline, all operations + every error path)
- [ ] README: parentheses philosophy + derivation section + Known limitations
- [ ] grammar vignette
- [ ] NEWS + version bump
- [ ] Adversarial self-review
